### PR TITLE
Hook up CSV to DB operations module to /api/upload endpoint

### DIFF
--- a/src/CsvToInsert.py
+++ b/src/CsvToInsert.py
@@ -2,6 +2,7 @@ import glob, os
 import csv
 import re
 import db.connection as connection
+import io
 from psycopg2.extras import RealDictCursor
 
 class CsvToInsert:
@@ -25,52 +26,63 @@ class CsvToInsert:
     def getDays(self, daySequenceStr):
         return set(filter(lambda day: day, re.split("(?:(M|T|W|R|F))", daySequenceStr)))
 
-    def populateDBFromCSVDataSourceDirectoryPath(self, csv_data_directory):
-        raw_conn = self.db.getConnection()
-        os.chdir(csv_data_directory)
-        with raw_conn.cursor(cursor_factory=RealDictCursor) as transaction:
-            try:
-                defaultSemester = "Summer 2020"
-                defaultDateStart = "2020-01-01"
-                defaultDateEnd = "2020-01-01"
-                for file in glob.glob("*.csv"):
-                    with open(file, "r") as csvfile:
-                        reader = csv.DictReader(csvfile)
-                        for row in reader:
-                            days = self.getDays(row['course_days_of_the_week']);
-                            # Change this if day of the week can be NULL
-                            if (len(days) > 0):
-                                for day in days:
-                                    transaction.execute(
-                                        "INSERT INTO course_session VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartTime)s, %(EndTime)s, %(WeekDay)s);",
-                                        {
-                                            "CRN": row['course_crn'],
-                                            "Section": row['course_section'],
-                                            "Semester": defaultSemester,
-                                            "StartTime": row['course_start_time'],
-                                            "EndTime": row['course_end_time'],
-                                            "WeekDay": self.dayToNum(day)
-                                        }
-                                    )
-                            transaction.execute(
-                                "INSERT INTO course VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartDate)s, %(EndDate)s, %(Department)s, %(Level)s, %(Title)s);",
-                                {
-                                    "CRN": row['course_crn'],
-                                    "Section": row['course_section'],
-                                    "Semester": defaultSemester,
-                                    "StartDate": defaultDateStart,
-                                    "EndDate": defaultDateEnd,
-                                    "Department": row['course_department'],
-                                    "Level": row['course_level'],
-                                    "Title": row['course_name'],
-                                }
-                            )
-                raw_conn.commit()
-            except Exception as e:
-                print(e)
-                raw_conn.rollback()
+    def populateDBFromCSVDataSourceDirectoryPath(self, files):
+        if (type(files) is list and len(files) > 0):
+            raw_conn = self.db.getConnection()
+            with raw_conn.cursor(cursor_factory=RealDictCursor) as transaction:
+                try:
+                    defaultSemester = "Summer 2020"
+                    defaultDateStart = "2020-01-01"
+                    defaultDateEnd = "2020-01-01"
+                    for raw_file in files:
+                        csvfile = None
+                        if (type(raw_file) == str and '.' in raw_file and raw_file.rsplit('.')[1] == 'csv') or (isinstance(raw_file, io.FileIO) and raw_file.filename and '.' in raw_file.filename and raw_file.filename.rsplit('.')[1] == 'csv') or isinstance(raw_file, io.StringIO):
+                            if type(raw_file) == str or (isinstance(raw_file, io.FileIO) and raw_file.closed == True):
+                                csvfile = open(raw_file, "r")
+                            else:
+                                csvfile = raw_file
+                            print(csvfile)
+                            # From the API endpoint, /api/upload or whatever the CSV upload is, the file objects will currently
+                            # be StringIO. Cannot check the extension of this since it's a temp in-memory file. Will just let
+                            # the error flow to the catch block.
+                            reader = csv.DictReader(csvfile)
+                            for row in reader:
+                                days = self.getDays(row['course_days_of_the_week'])
+                                # Change this if day of the week can be NULL
+                                if (len(days) > 0):
+                                    for day in days:
+                                        transaction.execute(
+                                            "INSERT INTO testCourseSession VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartTime)s, %(EndTime)s, %(WeekDay)s);",
+                                            {
+                                                "CRN": row['course_crn'],
+                                                "Section": row['course_section'],
+                                                "Semester": defaultSemester,
+                                                "StartTime": row['course_start_time'],
+                                                "EndTime": row['course_end_time'],
+                                                "WeekDay": self.dayToNum(day)
+                                            }
+                                        )
+                                transaction.execute(
+                                    "INSERT INTO testCourse VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartDate)s, %(EndDate)s, %(Department)s, %(Level)s, %(Title)s);",
+                                    {
+                                        "CRN": row['course_crn'],
+                                        "Section": row['course_section'],
+                                        "Semester": defaultSemester,
+                                        "StartDate": defaultDateStart,
+                                        "EndDate": defaultDateEnd,
+                                        "Department": row['course_department'],
+                                        "Level": row['course_level'],
+                                        "Title": row['course_name'],
+                                    }
+                                )
+                        raw_conn.commit()
+                except Exception as e:
+                    print(e)
+                    raw_conn.rollback()
 
 # Test Driver
 if __name__ == "__main__":
+    os.chdir(os.path.abspath("../rpi-data"))
+    fileNames = glob.glob("*.csv")
     insertJob = CsvToInsert(connection.db)
-    insertJob.populateDBFromCSVDataSourceDirectoryPath(os.path.abspath("../rpi-data"))
+    insertJob.populateDBFromCSVDataSourceDirectoryPath(fileNames)

--- a/src/CsvToInsert.py
+++ b/src/CsvToInsert.py
@@ -41,40 +41,40 @@ class CsvToInsert:
                                 csvfile = open(raw_file, "r")
                             else:
                                 csvfile = raw_file
-                            print(csvfile)
-                            # From the API endpoint, /api/upload or whatever the CSV upload is, the file objects will currently
-                            # be StringIO. Cannot check the extension of this since it's a temp in-memory file. Will just let
-                            # the error flow to the catch block.
-                            reader = csv.DictReader(csvfile)
-                            for row in reader:
-                                days = self.getDays(row['course_days_of_the_week'])
-                                # Change this if day of the week can be NULL
-                                if (len(days) > 0):
-                                    for day in days:
-                                        transaction.execute(
-                                            "INSERT INTO testCourseSession VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartTime)s, %(EndTime)s, %(WeekDay)s);",
-                                            {
-                                                "CRN": row['course_crn'],
-                                                "Section": row['course_section'],
-                                                "Semester": defaultSemester,
-                                                "StartTime": row['course_start_time'],
-                                                "EndTime": row['course_end_time'],
-                                                "WeekDay": self.dayToNum(day)
-                                            }
-                                        )
-                                transaction.execute(
-                                    "INSERT INTO testCourse VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartDate)s, %(EndDate)s, %(Department)s, %(Level)s, %(Title)s);",
-                                    {
-                                        "CRN": row['course_crn'],
-                                        "Section": row['course_section'],
-                                        "Semester": defaultSemester,
-                                        "StartDate": defaultDateStart,
-                                        "EndDate": defaultDateEnd,
-                                        "Department": row['course_department'],
-                                        "Level": row['course_level'],
-                                        "Title": row['course_name'],
-                                    }
-                                )
+                            with csvfile:
+                                # From the API endpoint, /api/upload or whatever the CSV upload is, the file objects will currently
+                                # be StringIO. Cannot check the extension of this since it's a temp in-memory file. Will just let
+                                # the error flow to the catch block.
+                                reader = csv.DictReader(csvfile)
+                                for row in reader:
+                                    days = self.getDays(row['course_days_of_the_week'])
+                                    # Change this if day of the week can be NULL
+                                    if (len(days) > 0):
+                                        for day in days:
+                                            transaction.execute(
+                                                "INSERT INTO testCourseSession VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartTime)s, %(EndTime)s, %(WeekDay)s);",
+                                                {
+                                                    "CRN": row['course_crn'],
+                                                    "Section": row['course_section'],
+                                                    "Semester": defaultSemester,
+                                                    "StartTime": row['course_start_time'],
+                                                    "EndTime": row['course_end_time'],
+                                                    "WeekDay": self.dayToNum(day)
+                                                }
+                                            )
+                                    transaction.execute(
+                                        "INSERT INTO testCourse VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartDate)s, %(EndDate)s, %(Department)s, %(Level)s, %(Title)s);",
+                                        {
+                                            "CRN": row['course_crn'],
+                                            "Section": row['course_section'],
+                                            "Semester": defaultSemester,
+                                            "StartDate": defaultDateStart,
+                                            "EndDate": defaultDateEnd,
+                                            "Department": row['course_department'],
+                                            "Level": row['course_level'],
+                                            "Title": row['course_name'],
+                                        }
+                                    )
                         raw_conn.commit()
                 except Exception as e:
                     print(e)

--- a/src/CsvToInsert.py
+++ b/src/CsvToInsert.py
@@ -52,7 +52,7 @@ class CsvToInsert:
                                     if (len(days) > 0):
                                         for day in days:
                                             transaction.execute(
-                                                "INSERT INTO testCourseSession VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartTime)s, %(EndTime)s, %(WeekDay)s);",
+                                                "INSERT INTO course_session VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartTime)s, %(EndTime)s, %(WeekDay)s);",
                                                 {
                                                     "CRN": row['course_crn'],
                                                     "Section": row['course_section'],
@@ -63,7 +63,7 @@ class CsvToInsert:
                                                 }
                                             )
                                     transaction.execute(
-                                        "INSERT INTO testCourse VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartDate)s, %(EndDate)s, %(Department)s, %(Level)s, %(Title)s);",
+                                        "INSERT INTO course VALUES (%(CRN)s, %(Section)s, %(Semester)s, %(StartDate)s, %(EndDate)s, %(Department)s, %(Level)s, %(Title)s);",
                                         {
                                             "CRN": row['course_crn'],
                                             "Section": row['course_section'],

--- a/src/app.py
+++ b/src/app.py
@@ -2,8 +2,14 @@
 from flask import Flask
 from flask import send_from_directory
 from flask import jsonify
+from flask import Response
+from flask import request
 import db.connection as connection
 import db.classinfo as ClassInfo
+
+from CsvToInsert import CsvToInsert
+
+from io import StringIO
 
 # - init interfaces to db
 db_conn = connection.db
@@ -43,6 +49,25 @@ def js(file):
 def get_classes():
     return jsonify(class_info.get_classes_full())
 
+@app.route('/api/upload', methods=['POST'])
+def uploadHandler():
+    if len(request.files) > 0:
+        files = []
+        for _, file in request.files.items():
+            if ('.' in file.filename and file.filename.rsplit('.')[1] == 'csv'):
+                # Flask opens passed files from POST in binary mode by default
+                content = file.read().decode()
+                # https://stackoverflow.com/questions/3305926/python-csv-string-to-array
+                tempFile = StringIO(content)
+                files.append(tempFile)
+            else:
+                print("not csv file")
+        print(files)
+        csvToDBInsertJob = CsvToInsert(connection.db)
+        csvToDBInsertJob.populateDBFromCSVDataSourceDirectoryPath(files)
+    # for key, value in request.form.items():
+    #     print(key, value)
+    return Response("Received file(s)", 200)
 
 if __name__ == '__main__':
     app.run()

--- a/src/public/templates/admin.html
+++ b/src/public/templates/admin.html
@@ -20,7 +20,10 @@
         <div class="well well-sm">
           Input course data as CSV, for more info, see: <a href=#>http://help.com</a> (show github link for more docs later)
         </div>
-        <input type="file" name="" value="">
+        <form action="/api/upload" method="POST" enctype="multipart/form-data">
+          <input type="file" name="file" />
+          <input type="Submit" value="Submit">
+        </form>
       </section>
     </div>
   </body>


### PR DESCRIPTION
This PR aims to implement the feature described in issue #4 . Basic functionality. Can only upload one file from the admin UI, but the capability for multiple files is there on the backend.

`populateDBFromCSVDataSourceDirectoryPath(self, files)` has been changed to allow for passing in a list of files, where the element may either be a file path, file obj (from open()), or the [StringIO](https://docs.python.org/3/library/io.html#io.StringIO) class.

Flow:
1. Navigate to /admin
2. Upload a .csv file, otherwise no DB change will occur on backend
3. Submit
4. The request object that is part of Flask is read for the `.files` property, and if it exists, then an in-memory duplicate of each file is created because Flask by default opens the file in binary mode. Neither the built-in CSV module or Pandas CSV utilities can take in a binary file so this was my workaround. I imagine Flask has a built-in request object size limit so may need to rework this if expecting massive files.
5. These in-memory files are passed off to an instance of CsvToInsert and the DB tables `course` and `course_session` are populated based off these.