### PR TITLE
Filter by dept & sub-semester

### DIFF
--- a/src/db/classinfo.py
+++ b/src/db/classinfo.py
@@ -25,6 +25,8 @@ class ClassInfo:
               c.level,
               concat(c.department, '-', c.level) as name,
               max(c.title) as title,
+              c.date_start,
+              c.date_end,
               json_agg(
                 row_to_json(section.*)
               ) sections
@@ -54,7 +56,9 @@ class ClassInfo:
               c.level = section.level
             group by
               c.department,
-              c.level
+              c.level,
+              c.date_start,
+              c.date_end
         """, None, True)
 
     def get_departments(self):

--- a/src/db/courses.py
+++ b/src/db/courses.py
@@ -22,7 +22,6 @@ class Courses:
         day_num = day_map.get(day_char, -1)
         if day_num != -1:
             return day_num
-            print(day_num)
         else:
             raise Exception("Invalid day code provided")
 
@@ -34,7 +33,6 @@ class Courses:
         conn = self.db.get_connection()
         reader = csv.DictReader(csv_text)
         for row in reader:
-            print(row)
             # for each course entry insert sections and course sessions
             with conn.cursor(cursor_factory=RealDictCursor) as transaction:
                 try:

--- a/src/public/js/scheduling.js
+++ b/src/public/js/scheduling.js
@@ -2,13 +2,29 @@ angular.module('yacs', [])
   .controller('schedule', ['$scope', '$http', function($scope, $http) {
 
     $scope.textSearch = ''
+    $scope.departmentSearch = ''
+    $scope.selectedSubsemester = ''
     $scope.classList = []
+
+    $scope.subsemesterSearch = function (desiredSubsemester) {
+      return function (subsemester) {
+        if (desiredSubsemester) {
+          return (desiredSubsemester.date_start.getTime() === subsemester.date_start.getTime() && desiredSubsemester.date_end.getTime() === subsemester.date_end.getTime())
+        }
+        return true
+      }
+    }
 
     // populate class list
     $http
       .get('/api/class')
       .then(res => {
         $scope.classList = res.data
+        $scope.classList.forEach(course => {
+          course.date_start = new Date(course.date_start)
+          course.date_end = new Date(course.date_end)
+        })
+        console.log(res.data);
       })
       .catch(err => {
         console.error(err);
@@ -34,7 +50,6 @@ angular.module('yacs', [])
         $scope.subsemesters.forEach(subsemester => {
           subsemester.date_start = new Date(subsemester.date_start)
           subsemester.date_end = new Date(subsemester.date_end)
-          console.log(subsemester)
           subsemester.date_start_display = (subsemester.date_start.getMonth() + 1) + "/" + (subsemester.date_start.getDate() + 1)
           subsemester.date_end_display = (subsemester.date_end.getMonth() + 1) + "/" + (subsemester.date_end.getDate() + 1)
         })

--- a/src/public/templates/admin.html
+++ b/src/public/templates/admin.html
@@ -20,7 +20,7 @@
           Input course data as CSV, for more info, see: <a href=#>http://help.com</a> (show github link for more docs later)
         </div>
         <form action="/api/courses" method="POST" enctype="multipart/form-data" class="form-group">
-          <input type="file" class="form-control-file"> <br>
+          <input type="file" name="file" class="form-control-file"> <br>
           <input type="Submit" class='btn btn-success btn-sm' value="Submit">
         </form>
       </section>

--- a/src/public/templates/schedule.html
+++ b/src/public/templates/schedule.html
@@ -40,7 +40,8 @@
               </div>
               <div class="form-group">
                 <label for="sub-semester">Filter Sub-Semester</label>
-                <select id='sub-semester' class="form-control">
+                <select id='sub-semester' ng-model='selectedSubsemester' class="form-control">
+                  <option value="" selected>All</option>
                   <option ng-value="subsemester" ng-repeat='subsemester in subsemesters'>
                     {{subsemester.date_start_display}} - {{subsemester.date_end_display}}
                   </option>
@@ -48,7 +49,8 @@
               </div>
               <div class="form-group">
                 <label for="department">Filter Department</label>
-                <select id='department' class="form-control">
+                <select id='department' ng-model='departmentSearch' class="form-control">
+                  <option value="" selected>All</option>
                   <option ng-value="department" ng-repeat='department in departments'>
                     {{department}}
                   </option>
@@ -59,18 +61,10 @@
             <hr>
 
             <div class="course-list">
-              <div class="course-list-element" ng-repeat='class in classList | filter:textSearch'>
+              <div class="course-list-element" ng-repeat="class in classList | filter:textSearch | filter:{department: departmentSearch} | filter:subsemesterSearch(selectedSubsemester)">
                 <b>{{ class.name }} (4 Credits)</b>
                 <p> {{ class.title }} <i>by Professor Kuzmin</i></p>
               </div>
-              <!-- <div class="course-list-element">
-                <b>MGMT-2300 (4 Credits)</b>
-                <p>Financial Accounting <i>by Elberg. H</i></p>
-              </div>
-              <div class="course-list-element">
-                <b>CSCI-5600 (3 Credits)</b>
-                <p>Principles of Software <i>by Professor Kuzmin</i></p>
-              </div> -->
             </div>
 
           </section>


### PR DESCRIPTION
This PR implements the feature described in #8. I have also added a default 'All' option for both department and subsection dropdowns.

I had to add the date_start and date_end fields in the SQL for what was being returned from `/api/class`.

Because of this, those fields had to be added to the GROUP BY clause which means "duplicate" courses are returned (at least from a user perspective). These duplicate courses are those that have multiple start and end dates. As of the `/rpi-data/summer-2020.csv` file, these are those courses:

```
 department | level
------------+-------              
 ENGR       |  2250  
 STSS       |  4100 
 ENGR       |  4010 
 ECON       |  4230 
(4 rows)
```

Each one of these has a 'duplicate' that will appear in the UI. Previously, `get_classes_full` returned 134 records. Now 138 are returned.

I'm not sure how this should be handled, so, I'll defer. But, filtering does work.