### PR TITLE
Remove jquery dependency

### DIFF
--- a/src/yacs-web/package-lock.json
+++ b/src/yacs-web/package-lock.json
@@ -6901,11 +6901,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
-      "integrity": "sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ="
-    },
     "js-message": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",

--- a/src/yacs-web/package.json
+++ b/src/yacs-web/package.json
@@ -14,7 +14,6 @@
     "axios": "^0.19.2",
     "bootstrap-vue": "^2.1.0",
     "core-js": "^3.6.4",
-    "jquery": "^1.9.1",
     "moment": "^2.24.0",
     "moment-locales-webpack-plugin": "^1.1.2",
     "vue": "^2.6.11",


### PR DESCRIPTION
Mistakenly added jquery to dependency list when I setup the project with BootstrapVue

According to BootstrapVue documentation https://bootstrap-vue.js.org/docs/
> Vue.js v2.6 is required, v2.6.11 is recommended
> Bootstrap 4.3.1 is required, v4.4.1 is recommended
> PortalVue v2.1 is required by Toasts, v2.1.7 is recommended
> jQuery is not required