### PR TITLE
Fix schedule grid width causing horizontal page scroll

### DIFF
--- a/src/web/src/components/Schedule.vue
+++ b/src/web/src/components/Schedule.vue
@@ -142,7 +142,7 @@ export default {
      * Return % width for each column
      */
     dayWidth() {
-      return 100 / this.numDays - 1;
+      return 100 / this.numDays;
     },
     /**
      * Return % height for each hour row
@@ -155,8 +155,10 @@ export default {
 </script>
 
 <style scoped lang="scss">
+$labelOffset: 0.35em;
+$hourFontSize: 0.5em;
+
 .schedule {
-  margin-right: 15px;
   margin-top: 10px;
   position: relative; /* so the overlay will position properly */
   margin-bottom: 15px;
@@ -165,20 +167,20 @@ export default {
 .schedule-legend {
   position: absolute;
   height: 100%;
-  left: 0.35em;
+  left: $labelOffset;
   top: 0.7em;
 }
 
 .hour-label {
   color: #777777;
-  font-size: 0.5em;
+  font-size: $hourFontSize;
   text-align: right;
   font-variant: small-caps;
 }
 
 .schedule-grid {
   position: absolute;
-  width: 99%;
+  width: calc(100% - #{$hourFontSize + $labelOffset + 1.7em});
   height: 100%;
   left: 2.5em;
 }
@@ -193,7 +195,6 @@ export default {
 }
 
 .grid-day {
-  //width: 1000;
   height: 100%;
   float: left;
 }
@@ -203,7 +204,6 @@ export default {
   box-sizing: border-box;
   border-top: 1px solid #e7e7e7;
   border-right: 1px solid #e7e7e7;
-  //position: relative;
 }
 
 .grid-day:last-of-type .grid-hour {

--- a/src/web/src/components/Schedule.vue
+++ b/src/web/src/components/Schedule.vue
@@ -160,6 +160,7 @@ $hourFontSize: 0.5em;
 
 .schedule {
   margin-top: 10px;
+  margin-right: 15px;
   position: relative; /* so the overlay will position properly */
   margin-bottom: 15px;
 }
@@ -180,7 +181,7 @@ $hourFontSize: 0.5em;
 
 .schedule-grid {
   position: absolute;
-  width: calc(100% - #{$hourFontSize + $labelOffset + 1.7em});
+  width: calc(100% - #{$hourFontSize + $labelOffset + 1.75em});
   height: 100%;
   left: 2.5em;
 }


### PR DESCRIPTION
On smaller screens the grid part of the schedule is exceeding its containers boundaries. This is a fix
for that by computing the width instead of the `width: 99%` that it was previously.

I've also gotten rid of the right-margin on the schedule grid since the grid is having its width being explicitly set it's easier to figure out a correct offset without considering margins and such.

Notice the little scrollbar on the bottom:

![image](https://user-images.githubusercontent.com/28029704/77987892-067ca580-72e9-11ea-91ae-85adf0785a60.png)

After:

![image](https://user-images.githubusercontent.com/28029704/77988260-e0a3d080-72e9-11ea-8672-ce80acfb0842.png)

