### PR TITLE
Fix course list layout break

### DIFF
--- a/src/web/src/components/CourseList.vue
+++ b/src/web/src/components/CourseList.vue
@@ -101,8 +101,9 @@ export default {
 <style scoped lang="scss">
 #scroll-box {
   overflow-y: scroll !important;
-  overflow-x: auto;
-  height: 0px; // allows flex and scroll combo
-              // flex-grow will set height during runtime
+  overflow-x: hidden;
+  flex-basis: 0px; // allows flex and scroll combo
+                   // flex-grow will set height during runtime
+  min-height: 200px; // fix for when at breakpoint <= md. Height isn't filling for some reason.
 }
 </style>

--- a/src/web/src/pages/Main.vue
+++ b/src/web/src/pages/Main.vue
@@ -6,9 +6,9 @@
         <b-col md="4" class="d-flex flex-column">
           <b-card no-body class="h-100">
             <b-tabs card class="h-100 d-flex flex-column flex-grow-1">
-              <b-tab title="Course Search" active class="flex-grow-1">
-                <b-card-text class="d-flex flex-grow-1">
-                  <CourseList @addCourse="addCourse" @removeCourse="removeCourse" :courses="courses" />
+              <b-tab title="Course Search" active class="flex-grow-1 w-100">
+                <b-card-text class="d-flex flex-grow-1 w-100">
+                  <CourseList @addCourse="addCourse" @removeCourse="removeCourse" :courses="courses" class="w-100"/>
                 </b-card-text>
               </b-tab>
               <b-tab class="flex-grow-1">


### PR DESCRIPTION
Not sure why in the courselist the list-group-item is exceeding its container. Set width to 100% on parents.

![image](https://user-images.githubusercontent.com/28029704/78075301-48056300-7372-11ea-9dda-e88e4a5fe2f5.png)

Closes #83
