### PR TITLE
Increase fileupload size

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -78,8 +78,10 @@ def set_defaultSemester():
 @app.route('/api/bulkCourseUpload', methods=['POST'])
 def uploadHandler():
     # check for user files
-    if not len(request.files):
-        return Response("Need a *.csv file", 400)
+    if not request.files:
+        return Response("No file received", 400)
+    if request.files['file'].filename.rsplit('.', 1)[1].lower() != 'csv':
+        return Response("File must have csv extension", 400)
     # get file
     csv_file = StringIO(request.files['file'].read().decode())
     isSuccess, error = courses.populate_from_csv(csv_file)

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -27,6 +27,7 @@ http {
     # Serve API routes
     location /api {
       proxy_pass http://yacs_api:5000;
+      client_max_body_size 3M;
     }
 
   }


### PR DESCRIPTION
Because of #96, semester CSVs are growing larger and it currently isn't possible to upload those CSVs from the admin panel. This PR fixes that.

To test:

go to /admin -> upload csv modal -> upload a CSV with >= 1.5 MB -> shouldn't get HTTP 413