### PR TITLE
Fix semester options not being updated in course list

### DIFF
--- a/src/web/src/components/CourseList.vue
+++ b/src/web/src/components/CourseList.vue
@@ -44,9 +44,7 @@ import '@/typedef';
 
 import { DAY_SHORTNAMES } from '@/utils';
 
-import { getDepartments, getSubSemesters } from '@/services/YacsService';
-
-import { getDefaultSemester } from '@/services/AdminService';
+import { getDepartments } from '@/services/YacsService';
 
 import CourseListingComponent from '@/components/CourseListing';
 
@@ -57,6 +55,7 @@ export default {
   },
   props: {
     courses: Array,
+    subsemesters: Array,
     selectedSemester: null
   },
   data() {
@@ -64,32 +63,27 @@ export default {
       DAY_SHORTNAMES,
       textSearch: null,
       selectedSubsemester: null,
-      subsemesterOptions: [{ text: 'All', value: null }],
       selectedDepartment: null,
       departmentOptions: [{ text: 'All', value: null }]
     };
   },
   created() {
-    if(this.$route.query.semester){
-      this.selectedSemester = this.$route.query.semester;
-    }
-    else{
-      getDefaultSemester().then(semester => {
-        this.selectedSemester = semester;
-      });
-    }
     getDepartments().then(departments => {
       this.departmentOptions.push(...departments.map(d => d.department));
     });
-    getSubSemesters().then(subsemesters => {
-      this.subsemesterOptions.push(
-        ...subsemesters.filter(subsemester => subsemester.semester_name === this.selectedSemester)
-        .map(subsemester => {
-          return { text: subsemester.display_string, value: subsemester };
-        }))
-    });
   },
   computed: {
+    subsemesterOptions() {
+      let options = [{ text: 'All', value: null }]
+      options.push(
+        ...this.subsemesters.map(subsemester => {
+          return { text: subsemester.display_string, value: subsemester }
+        })
+      );
+      // eslint-disable-next-line
+      this.selectedSubsemester = options[0].value;
+      return options;
+    },
     /**
      * Returns a list of courses that match the selected filters
      * @returns {Course[]}

--- a/src/web/src/components/CourseList.vue
+++ b/src/web/src/components/CourseList.vue
@@ -80,6 +80,8 @@ export default {
           return { text: subsemester.display_string, value: subsemester }
         })
       );
+      // Once we get new data for the <select>, v-model will retain its old value.
+      // Need to update this value after receving new data to keep values consistent.
       // eslint-disable-next-line
       this.selectedSubsemester = options[0].value;
       return options;

--- a/src/web/src/services/YacsService.js
+++ b/src/web/src/services/YacsService.js
@@ -71,8 +71,12 @@ export const getDepartments = () =>
  * Returns a list of all subsemesters
  * @returns {Promise<Subsemester[]>}
  */
-export const getSubSemesters = () =>
-  client.get('/subsemester').then(({ data }) => {
+export const getSubSemesters = (semester) =>
+  client.get('/subsemester', {
+    params: {
+      "semester": semester
+    }
+  }).then(({ data }) => {
     return data.map(subsemester => {
       subsemester.date_start = localToUTCDate(new Date(subsemester.date_start));
       subsemester.date_end = localToUTCDate(new Date(subsemester.date_end));


### PR DESCRIPTION
**Description**

This PR aims to fix subsemesters in the CourseList and Schedule components not being updated when changing semester. This happened because most of the initialization code is in `created()` but the semester changing from the footer is dynamic and doesn't reload the page.

**Related Issue**

N/A

**Database Changes/Migrations**

N/A

**Test Modifications**

N/A

**Test Procedure**

- Have Summer & Fall semesters loaded into the DB
- Go to schedule page
- Switch between Fall & Summer semesters from the footer buttons and the subsemesters should update accordingly. Where Fall would have no subsemesters but Summer would.

**Images**

Initially loaded Summer 2020, course listing subsemester options
![image](https://user-images.githubusercontent.com/28029704/79832010-8345f100-8376-11ea-98b8-541399abaebd.png)

Summer 2020 schedule subsemester options
![image](https://user-images.githubusercontent.com/28029704/79832030-8e008600-8376-11ea-9dc9-f3fcacefa8ca.png)

After switching to Fall 2020, subsemester options correctly go away
![image](https://user-images.githubusercontent.com/28029704/79832049-9953b180-8376-11ea-8760-ee27d5e04e2b.png)
