### PR TITLE
Add loading spinner to course list

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1,18 +1,70 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="https://user-images.githubusercontent.com/11034221/80246576-a274a500-863a-11ea-8d18-93ef2c095b7b.jpg">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <link
+      rel="icon"
+      href="https://user-images.githubusercontent.com/11034221/80246576-a274a500-863a-11ea-8d18-93ef2c095b7b.jpg"
+    />
     <script src="./ics.min.js" type="application/javascript"></script>
     <title>YACS</title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong
+        >We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without
+        JavaScript enabled. Please enable it to continue.</strong
+      >
     </noscript>
-    <div id="app"></div>
+    <div id="app">
+      <!-- Everything in here gets replaced when Vue loads -->
+      <div class="loadContainer">
+        <div class="loader"></div>
+        <h1>Loading YACS...</h1>
+      </div>
+      <style>
+        #app,
+        body,
+        html {
+          height: 100%;
+          width: 100%;
+        }
+
+        .loadContainer {
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+          height: 100%;
+          justify-content: center;
+          align-items: center;
+        }
+
+        .loader {
+          border: 16px solid black;
+          /* Light grey */
+          border-top: 16px solid white;
+          /* Blue */
+          border-radius: 50%;
+          width: 120px;
+          height: 120px;
+          margin-bottom: 10px;
+
+          animation: spin 2s linear infinite;
+        }
+
+        @keyframes spin {
+          0% {
+            transform: rotate(0deg);
+          }
+
+          100% {
+            transform: rotate(360deg);
+          }
+        }
+      </style>
+    </div>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -18,53 +18,7 @@
         JavaScript enabled. Please enable it to continue.</strong
       >
     </noscript>
-    <div id="app">
-      <!-- Everything in here gets replaced when Vue loads -->
-      <div class="loadContainer">
-        <div class="loader"></div>
-        <h1>Loading YACS...</h1>
-      </div>
-      <style>
-        #app,
-        body,
-        html {
-          height: 100%;
-          width: 100%;
-        }
-
-        .loadContainer {
-          display: flex;
-          flex-direction: column;
-          width: 100%;
-          height: 100%;
-          justify-content: center;
-          align-items: center;
-        }
-
-        .loader {
-          border: 16px solid black;
-          /* Light grey */
-          border-top: 16px solid white;
-          /* Blue */
-          border-radius: 50%;
-          width: 120px;
-          height: 120px;
-          margin-bottom: 10px;
-
-          animation: spin 2s linear infinite;
-        }
-
-        @keyframes spin {
-          0% {
-            transform: rotate(0deg);
-          }
-
-          100% {
-            transform: rotate(360deg);
-          }
-        }
-      </style>
-    </div>
+    <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/src/web/src/pages/Main.vue
+++ b/src/web/src/pages/Main.vue
@@ -48,7 +48,7 @@
         </b-col>
         <b-col md="8">
           <b-form-select
-            v-if="!loading && scheduler.scheduleSubsemesters.length > 1"
+            v-if="!loading && scheduler.scheduleSubsemesters && scheduler.scheduleSubsemesters.length > 1"
             v-model="selectedScheduleSubsemester"
             :options="scheduler.scheduleSubsemesters"
             text-field="display_string"

--- a/src/web/src/pages/Main.vue
+++ b/src/web/src/pages/Main.vue
@@ -8,7 +8,16 @@
             <b-tabs card class="h-100 d-flex flex-column flex-grow-1">
               <b-tab title="Course Search" active class="flex-grow-1 w-100">
                 <b-card-text class="d-flex flex-grow-1 w-100">
+                  <div
+                    v-if="loading"
+                    class="d-flex flex-grow-1 flex-column w-100 justify-content-center align-items-center"
+                  >
+                    <b-spinner></b-spinner>
+
+                    <strong>Loading courses...</strong>
+                  </div>
                   <CourseList
+                    v-if="!loading"
                     @addCourse="addCourse"
                     @removeCourse="removeCourse"
                     :courses="courses"
@@ -39,7 +48,7 @@
         </b-col>
         <b-col md="8">
           <b-form-select
-            v-if="scheduler.scheduleSubsemesters.length > 1"
+            v-if="!loading && scheduler.scheduleSubsemesters.length > 1"
             v-model="selectedScheduleSubsemester"
             :options="scheduler.scheduleSubsemesters"
             text-field="display_string"
@@ -65,17 +74,14 @@
                 class="col-auto btn-sm btn btn-primary ml-auto mb-2 mr-5 mt-1 d-block"
                 @click="exportScheduleToIcs"
               >
-                <font-awesome-icon :icon="exportIcon" /> Export to ICS
+                <font-awesome-icon :icon="exportIcon" />Export to ICS
               </button>
             </b-col>
           </b-row>
         </b-col>
       </b-row>
     </b-container>
-    <Footer
-      :semester="currentSemester"
-      @changeCurrentSemester="updateCurrentSemester"
-    />
+    <Footer :semester="currentSemester" @changeCurrentSemester="updateCurrentSemester" />
   </div>
 </template>
 
@@ -87,11 +93,18 @@ import SelectedCoursesComponent from '@/components/SelectedCourses';
 import CourseListComponent from '@/components/CourseList';
 import Footer from '@/components/Footer';
 
+import Schedule from '@/controllers/Schedule';
 import SubSemesterScheduler from '@/controllers/SubSemesterScheduler';
 
 import HeaderComponent from '@/components/Header';
 
-import { getSubSemesters, getCourses, addStudentCourse, removeStudentCourse, getStudentCourses } from '@/services/YacsService';
+import {
+  getSubSemesters,
+  getCourses,
+  addStudentCourse,
+  removeStudentCourse,
+  getStudentCourses
+} from '@/services/YacsService';
 
 import { getDefaultSemester } from '@/services/AdminService';
 
@@ -111,74 +124,76 @@ export default {
     return {
       selectedCourses: {},
       selectedScheduleSubsemester: null,
-      scheduler: new SubSemesterScheduler(),
+      scheduler: new Schedule(),
       subsemesters: [],
       currentSemester: '',
       courses: [],
+      loading: false,
       exportIcon: faPaperPlane,
       ICS_DAY_SHORTNAMES: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
     };
   },
   async created() {
-    this.currentSemester = this.$route.query.semester ? this.$route.query.semester : await getDefaultSemester();
-
-    await this.updateDataOnNewSemester();
-    await this.loadStudentCourses(this.currentSemester);
-
+    this.updateCurrentSemester(
+      this.$route.query.semester ? this.$route.query.semester : await getDefaultSemester()
+    );
   },
   methods: {
-    async loadStudentCourses(semester){
+    async loadStudentCourses(semester) {
       this.selectedCourses = {};
-      this.userID = this.$cookies.get("userID");
+      this.userID = this.$cookies.get('userID');
 
-      if(this.userID && semester){
-        console.log("Loading user courses...")
-        try{
-          const info = {'uid': this.userID};
+      if (this.userID && semester) {
+        console.log('Loading user courses...');
+        try {
+          const info = { uid: this.userID };
           var cids = await getStudentCourses(info);
           console.log(cids);
 
           cids.forEach(cid => {
-            if(cid.semester == this.currentSemester){
+            if (cid.semester == this.currentSemester) {
               var c = this.courses.find(function(course) {
-                return ((course.name == cid.course_name) && (course.semester == cid.semester));});
+                return course.name == cid.course_name && course.semester == cid.semester;
+              });
 
-              if(cid.crn != '-1'){
-                var sect = c.sections.find(
-                  function(section) {return section.crn == cid.crn;}
-                );
+              if (cid.crn != '-1') {
+                var sect = c.sections.find(function(section) {
+                  return section.crn == cid.crn;
+                });
                 sect.selected = true;
                 this.scheduler.addCourseSection(c, sect);
-              }
-              else{
+              } else {
                 c.selected = true;
                 this.$set(this.selectedCourses, c.id, c);
                 this.scheduler.addCourse(c);
               }
             }
           });
-        }
-
-        catch(error){
+        } catch (error) {
           console.log(error);
         }
       }
     },
     updateDataOnNewSemester() {
       history.pushState(null, '', encodeURI(`/?semester=${this.currentSemester}`));
-      this.scheduler = new SubSemesterScheduler();
-      return Promise.all([getCourses(this.currentSemester), getSubSemesters(this.currentSemester)]).then(([courses, subsemesters]) => {
+      // this.scheduler = new SubSemesterScheduler();
+      return Promise.all([
+        getCourses(this.currentSemester),
+        getSubSemesters(this.currentSemester)
+      ]).then(([courses, subsemesters]) => {
         this.courses = courses;
         this.subsemesters = subsemesters;
         // Less work to create a new scheduler which is meant for a single semester
-        this.scheduler = new SubSemesterScheduler()
+        this.scheduler = new SubSemesterScheduler();
         // Filter out "full" subsemester
-        subsemesters.filter( (s, i, arr) =>
-            arr.length == 1 || !arr.every((o, oi) => oi == i || this.withinDuration(s, o))
-        )
-        .forEach(subsemester => {
-          this.scheduler.addSubSemester(subsemester);
-        });
+        subsemesters
+          .filter(
+            (s, i, arr) =>
+              arr.length == 1 || !arr.every((o, oi) => oi == i || this.withinDuration(s, o))
+          )
+          .forEach(subsemester => {
+            this.scheduler.addSubSemester(subsemester);
+          });
 
         if (this.scheduler.scheduleSubsemesters.length > 0) {
           this.selectedScheduleSubsemester = this.scheduler.scheduleSubsemesters[0].display_string;
@@ -209,8 +224,13 @@ export default {
         }
       }
 
-      if(this.userID){
-        const info = {'name':course.name, 'semester':this.currentSemester, 'uid':this.userID, 'cid':'-1'};
+      if (this.userID) {
+        const info = {
+          name: course.name,
+          semester: this.currentSemester,
+          uid: this.userID,
+          cid: '-1'
+        };
 
         addStudentCourse(info)
           .then(response => {
@@ -227,8 +247,13 @@ export default {
       this.scheduler.addCourseSection(course, section);
       section.selected = true;
 
-      if(this.userID){
-        const info = {'name':course.name, 'semester':this.currentSemester, 'uid':this.userID, 'cid':section.crn};
+      if (this.userID) {
+        const info = {
+          name: course.name,
+          semester: this.currentSemester,
+          uid: this.userID,
+          cid: section.crn
+        };
 
         addStudentCourse(info)
           .then(response => {
@@ -255,8 +280,13 @@ export default {
       course.selected = false;
       this.scheduler.removeAllCourseSections(course);
 
-      if(this.userID){
-        const info = {'name':course.name, 'semester':this.currentSemester, 'uid':this.userID, 'cid': null};
+      if (this.userID) {
+        const info = {
+          name: course.name,
+          semester: this.currentSemester,
+          uid: this.userID,
+          cid: null
+        };
 
         removeStudentCourse(info)
           .then(response => {
@@ -270,9 +300,14 @@ export default {
     },
     removeCourseSection(section) {
       this.scheduler.removeCourseSection(section);
-      if(this.userID){
+      if (this.userID) {
         var name = section.department + '-' + section.level;
-        const info = {'name':name, 'semester':this.currentSemester, 'uid':this.userID, 'cid':section.crn};
+        const info = {
+          name: name,
+          semester: this.currentSemester,
+          uid: this.userID,
+          cid: section.crn
+        };
 
         removeStudentCourse(info)
           .then(response => {
@@ -283,13 +318,14 @@ export default {
             console.log(error.response);
           });
       }
-
     },
     async updateCurrentSemester(sem) {
+      this.loading = true;
       this.currentSemester = sem;
       // history.pushState(null, '', encodeURI(`/?semester=${this.currentSemester}`));
       await this.updateDataOnNewSemester();
       await this.loadStudentCourses(this.currentSemester);
+      this.loading = false;
     },
 
     /**
@@ -397,8 +433,8 @@ export default {
   }
 }
 
-Footer{
-  margin:0px !important;
+footer {
+  margin: 0px !important;
 }
 
 #export-ics-button {

--- a/src/web/src/pages/Main.vue
+++ b/src/web/src/pages/Main.vue
@@ -107,7 +107,6 @@ import {
 } from '@/services/YacsService';
 
 import { getDefaultSemester } from '@/services/AdminService';
-
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons';
 
 export default {

--- a/src/web/src/pages/Main.vue
+++ b/src/web/src/pages/Main.vue
@@ -55,7 +55,7 @@
             value-field="display_string"
           ></b-form-select>
 
-          <template v-if="scheduler.schedules.length">
+          <template v-if="scheduler.schedules">
             <Schedule
               v-for="(schedule, index) in scheduler.schedules"
               :key="index"
@@ -63,6 +63,8 @@
               v-show="selectedScheduleIndex === index"
             />
           </template>
+          <Schedule v-else :schedule="scheduler"></Schedule>
+
           <b-row>
             <b-col>
               <h5>CRNs: {{ selectedCrns }}</h5>

--- a/src/web/src/pages/Main.vue
+++ b/src/web/src/pages/Main.vue
@@ -135,8 +135,9 @@ export default {
     };
   },
   async created() {
+    const querySemester = this.$route.query.semester;
     this.updateCurrentSemester(
-      this.$route.query.semester ? this.$route.query.semester : await getDefaultSemester()
+      querySemester && querySemester != 'null' ? querySemester : await getDefaultSemester()
     );
   },
   methods: {

--- a/src/web/src/pages/Main.vue
+++ b/src/web/src/pages/Main.vue
@@ -322,7 +322,6 @@ export default {
     async updateCurrentSemester(sem) {
       this.loading = true;
       this.currentSemester = sem;
-      // history.pushState(null, '', encodeURI(`/?semester=${this.currentSemester}`));
       await this.updateDataOnNewSemester();
       await this.loadStudentCourses(this.currentSemester);
       this.loading = false;


### PR DESCRIPTION


**Issue**

Closes #130 

**Database Changes/Migrations**
N/A

**Test Modifications**

N/A

**Test Procedure**

1. Load page
2. Switch semesters via links in footer
3. Course side panel should be replace by spinner

**Photos**
My mouse clicking is too slow
![Screen Shot 2020-04-26 at 1 01 56 PM](https://user-images.githubusercontent.com/9285017/80318311-2905bf80-87be-11ea-867e-409f4655301f.png)


**Additional Info**

Add loading to Main, toggle when updateSemesterData is called. Replace CourseList with b-spinner on load. Initialize main with Schedule to have schedule grid appear during load.