### PR TITLE
Change student page routes

### DIFF
--- a/src/web/src/components/Footer.vue
+++ b/src/web/src/components/Footer.vue
@@ -11,8 +11,8 @@
               v-for="option of otherSemesters"
               :key="option.text"
               class="link"
-              :disabled="option.text === semester"
-              @click="updateCurrentSemester(option.text)"
+              :disabled="option.text === selectedSemester"
+              @click="updateSelectedSemester(option.text)"
             >
               {{ option.value }}
             </a>
@@ -71,7 +71,7 @@ import { getSemesters } from "@/services/YacsService";
 export default {
   name: "Footer",
   props: {
-    semester: String,
+    selectedSemester: String,
   },
   data() {
     return {
@@ -79,9 +79,8 @@ export default {
     };
   },
   methods: {
-    updateCurrentSemester(to) {
-      console.log("in change emit of footer");
-      this.$emit("changeCurrentSemester", to);
+    updateSelectedSemester(newSemester) {
+      this.$emit("changeSelectedSemester", newSemester);
     },
   },
   computed: {

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -28,12 +28,12 @@
       <!-- If user has not logged in -->
       <b-navbar-nav class="ml-auto" v-if="sessionID === null">
         <div>
-          <b-button v-b-modal.modal-1 size="sm" variant="light">
+          <b-button v-b-modal.login-modal size="sm" variant="light">
             Log In
           </b-button>
 
           <b-button
-            v-b-modal.singup-modal
+            v-b-modal.signup-modal
             size="sm"
             variant="primary"
             class="ml-2"
@@ -41,8 +41,13 @@
             Sign Up
           </b-button>
 
-          <b-modal id="modal-1" ref="modal-1" hide-footer title="Log In">
-            <b-form @submit="onSubmit" @reset="onReset" v-if="show">
+          <b-modal
+            id="login-modal"
+            ref="login-modal"
+            hide-footer
+            title="Log In"
+          >
+            <b-form @submit="onSubmit" @reset="onReset" v-if="showForm">
               <b-form-group
                 id="input-group-1"
                 label="Email address:"
@@ -72,24 +77,10 @@
               </b-form-group>
 
               <b-button type="submit" variant="primary">Submit</b-button>
-
-              <!-- <b-button :pressed.sync="showSignUp" variant="primary" id="signUpButton">Sign Up</b-button> -->
             </b-form>
-
-            <div v-if="showSignUp">
-              <SignUpForm></SignUpForm>
-              <b-button :pressed.sync="showSignUp" variant="primary">
-                Go back to Log In
-              </b-button>
-            </div>
           </b-modal>
 
-          <b-modal
-            id="singup-modal"
-            ref="singup-modal"
-            hide-footer
-            title="Sign Up"
-          >
+          <b-modal id="signup-modal" hide-footer title="Sign Up">
             <SignUpForm></SignUpForm>
           </b-modal>
         </div>
@@ -120,10 +111,9 @@ export default {
       },
 
       isLoggedIn: false,
-      showSignUp: false,
       sessionID: "",
       userName: "",
-      show: true,
+      showForm: true,
       semesterOptions: [],
     };
   },
@@ -137,9 +127,6 @@ export default {
     }
   },
   methods: {
-    toggleModal() {
-      this.$refs["modal-1"].hide();
-    },
     onSubmit(evt) {
       evt.preventDefault();
       let userInfo = this.form;
@@ -164,7 +151,7 @@ export default {
             }
           );
         });
-      this.toggleModal();
+      this.$refs["login-modal"].hide();
     },
     onReset(evt) {
       evt.preventDefault();
@@ -172,9 +159,9 @@ export default {
       this.form.email = "aaa1@wa.com";
       this.form.password = "123456";
       // Trick to reset/clear native browser form validation state
-      this.show = false;
+      this.showForm = false;
       this.$nextTick(() => {
-        this.show = true;
+        this.showForm = true;
       });
     },
     logOut() {

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -2,7 +2,7 @@
   <div id="header">
     <b-navbar type="light" variant="light">
       <b-navbar-brand class="logo" href="#">YACS</b-navbar-brand>
-      <div class="semester">{{ currentSemester }}</div>
+      <div class="semester">{{ selectedSemester }}</div>
       <b-navbar-nav>
         <b-nav-item>
           <router-link :to="{ name: 'CourseScheduler' }">
@@ -98,7 +98,7 @@ import SignUpComponent from "@/components/SignUp";
 export default {
   name: "Header",
   props: {
-    currentSemester: String,
+    selectedSemester: String,
   },
   components: {
     SignUpForm: SignUpComponent,

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -3,6 +3,18 @@
     <b-navbar type="light" variant="light">
       <b-navbar-brand class="logo" href="#">YACS</b-navbar-brand>
       <div class="semester">{{ currentSemester }}</div>
+      <b-navbar-nav>
+        <b-nav-item>
+          <router-link :to="{ name: 'CourseScheduler' }">
+            Schedule
+          </router-link>
+        </b-nav-item>
+        <b-nav-item>
+          <router-link :to="{ name: 'CourseExplorer' }">
+            Explore
+          </router-link>
+        </b-nav-item>
+      </b-navbar-nav>
       <!-- If user has logged in -->
       <b-navbar-nav class="ml-auto" v-if="sessionID !== null">
         <b-nav-item-dropdown right>
@@ -95,7 +107,7 @@ import SignUpComponent from "@/components/SignUp";
 export default {
   name: "Header",
   props: {
-    semester: String,
+    currentSemester: String,
   },
   components: {
     SignUpForm: SignUpComponent,
@@ -114,14 +126,6 @@ export default {
       show: true,
       semesterOptions: [],
     };
-  },
-  computed: {
-    // When you assign a data var to a prop, the data var does not change on prop update (seems this is intended behavior)
-    // use computed instead to get current semester which reflects one in parent component.
-    // https://forum.vuejs.org/t/update-data-when-prop-changes-data-derived-from-prop/1517/15
-    currentSemester() {
-      return this.semester;
-    },
   },
   created() {
     this.sessionID = this.$cookies.get("sessionID");

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    Hi im the course explorer
+  </div>
+</template>
+
+<script>
+export default {
+  name: "CourseExplorer",
+  props: {
+    currentSemester: String,
+  },
+};
+</script>
+
+<style></style>

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -1,14 +1,21 @@
 <template>
-  <div>
-    Hi im the course explorer
-  </div>
+  <div>Hi im the course explorer with {{ this.courses.length }} courses</div>
 </template>
 
 <script>
+import { getCourses } from "../services/YacsService";
 export default {
   name: "CourseExplorer",
   props: {
     selectedSemester: String,
+  },
+  data() {
+    return {
+      courses: [],
+    };
+  },
+  async created() {
+    this.courses = await getCourses(this.selectedSemester);
   },
 };
 </script>

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -8,7 +8,7 @@
 export default {
   name: "CourseExplorer",
   props: {
-    currentSemester: String,
+    selectedSemester: String,
   },
 };
 </script>

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -22,7 +22,7 @@
                   :courses="courses"
                   :subsemesters="subsemesters"
                   class="w-100"
-                  :selectedSemester="currentSemester"
+                  :selectedSemester="selectedSemester"
                 />
               </b-card-text>
             </b-tab>
@@ -171,7 +171,7 @@ export default {
     CourseList: CourseListComponent,
   },
   props: {
-    currentSemester: String,
+    selectedSemester: String,
   },
   data() {
     return {
@@ -200,7 +200,7 @@ export default {
           console.log(cids);
 
           cids.forEach((cid) => {
-            if (cid.semester == this.currentSemester) {
+            if (cid.semester == this.selectedSemester) {
               var c = this.courses.find(function (course) {
                 return (
                   course.name == cid.course_name &&
@@ -228,8 +228,8 @@ export default {
     },
     updateDataOnNewSemester() {
       return Promise.all([
-        getCourses(this.currentSemester),
-        getSubSemesters(this.currentSemester),
+        getCourses(this.selectedSemester),
+        getSubSemesters(this.selectedSemester),
       ]).then(([courses, subsemesters]) => {
         this.courses = courses;
         this.subsemesters = subsemesters;
@@ -282,7 +282,7 @@ export default {
       if (this.userID) {
         const info = {
           name: course.name,
-          semester: this.currentSemester,
+          semester: this.selectedSemester,
           uid: this.userID,
           cid: "-1",
         };
@@ -305,7 +305,7 @@ export default {
       if (this.userID) {
         const info = {
           name: course.name,
-          semester: this.currentSemester,
+          semester: this.selectedSemester,
           uid: this.userID,
           cid: section.crn,
         };
@@ -342,7 +342,7 @@ export default {
       if (this.userID) {
         const info = {
           name: course.name,
-          semester: this.currentSemester,
+          semester: this.selectedSemester,
           uid: this.userID,
           cid: null,
         };
@@ -363,7 +363,7 @@ export default {
         var name = section.department + "-" + section.level;
         const info = {
           name: name,
-          semester: this.currentSemester,
+          semester: this.selectedSemester,
           uid: this.userID,
           cid: section.crn,
         };
@@ -570,7 +570,7 @@ export default {
     },
   },
   watch: {
-    currentSemester: {
+    selectedSemester: {
       immediate: true,
       handler(newSemester) {
         this.loading = true;

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -1,98 +1,91 @@
 <template>
-  <div>
-    <Header class="mb-3" :semester="currentSemester"></Header>
-    <b-container fluid class="py-3 h-100">
-      <b-row class="h-100">
-        <b-col md="4" class="d-flex flex-column">
-          <b-card no-body class="h-100">
-            <b-tabs card class="h-100 d-flex flex-column flex-grow-1">
-              <b-tab title="Course Search" active class="flex-grow-1 w-100">
-                <b-card-text class="d-flex flex-grow-1 w-100">
-                  <div
-                    v-if="loading"
-                    class="d-flex flex-grow-1 flex-column w-100 justify-content-center align-items-center"
-                  >
-                    <b-spinner></b-spinner>
+  <b-container fluid class="py-3 h-100">
+    <b-row class="h-100">
+      <b-col md="4" class="d-flex flex-column">
+        <b-card no-body class="h-100">
+          <b-tabs card class="h-100 d-flex flex-column flex-grow-1">
+            <b-tab title="Course Search" active class="flex-grow-1 w-100">
+              <b-card-text class="d-flex flex-grow-1 w-100">
+                <div
+                  v-if="loading"
+                  class="d-flex flex-grow-1 flex-column w-100 justify-content-center align-items-center"
+                >
+                  <b-spinner></b-spinner>
 
-                    <strong>Loading courses...</strong>
-                  </div>
-                  <CourseList
-                    v-if="!loading"
-                    @addCourse="addCourse"
-                    @removeCourse="removeCourse"
-                    @showCourseInfo="showCourseInfo"
-                    :courses="courses"
-                    :subsemesters="subsemesters"
-                    class="w-100"
-                    :selectedSemester="currentSemester"
-                  />
-                </b-card-text>
-              </b-tab>
-              <b-tab class="flex-grow-1">
-                <template v-slot:title>
-                  <div class="text-center">
-                    Selected Courses
-                    <b-badge variant="light">{{ numSelectedCourses }}</b-badge>
-                  </div>
-                </template>
-                <b-card-text class="w-100 d-flex flex-grow-1 flex-column">
-                  <SelectedCourses
-                    :courses="selectedCourses"
-                    @removeCourse="removeCourse"
-                    @removeCourseSection="removeCourseSection"
-                    @addCourseSection="addCourseSection"
-                  />
-                </b-card-text>
-              </b-tab>
-            </b-tabs>
-          </b-card>
-        </b-col>
-        <b-col md="8">
-          <b-form-select
-            v-if="
-              !loading &&
-              scheduler.scheduleSubsemesters &&
-              scheduler.scheduleSubsemesters.length > 1
-            "
-            v-model="selectedScheduleSubsemester"
-            :options="scheduler.scheduleSubsemesters"
-            text-field="display_string"
-            value-field="display_string"
-          ></b-form-select>
+                  <strong>Loading courses...</strong>
+                </div>
+                <CourseList
+                  v-if="!loading"
+                  @addCourse="addCourse"
+                  @removeCourse="removeCourse"
+                  @showCourseInfo="showCourseInfo"
+                  :courses="courses"
+                  :subsemesters="subsemesters"
+                  class="w-100"
+                  :selectedSemester="currentSemester"
+                />
+              </b-card-text>
+            </b-tab>
+            <b-tab class="flex-grow-1">
+              <template v-slot:title>
+                <div class="text-center">
+                  Selected Courses
+                  <b-badge variant="light">{{ numSelectedCourses }}</b-badge>
+                </div>
+              </template>
+              <b-card-text class="w-100 d-flex flex-grow-1 flex-column">
+                <SelectedCourses
+                  :courses="selectedCourses"
+                  @removeCourse="removeCourse"
+                  @removeCourseSection="removeCourseSection"
+                  @addCourseSection="addCourseSection"
+                />
+              </b-card-text>
+            </b-tab>
+          </b-tabs>
+        </b-card>
+      </b-col>
+      <b-col md="8">
+        <b-form-select
+          v-if="
+            !loading &&
+            scheduler.scheduleSubsemesters &&
+            scheduler.scheduleSubsemesters.length > 1
+          "
+          v-model="selectedScheduleSubsemester"
+          :options="scheduler.scheduleSubsemesters"
+          text-field="display_string"
+          value-field="display_string"
+        ></b-form-select>
 
-          <template v-if="scheduler.schedules">
-            <Schedule
-              v-for="(schedule, index) in scheduler.schedules"
-              :key="index"
-              :schedule="schedule"
-              v-show="selectedScheduleIndex === index"
-            />
-          </template>
-          <Schedule v-else :schedule="scheduler"></Schedule>
+        <template v-if="scheduler.schedules">
+          <Schedule
+            v-for="(schedule, index) in scheduler.schedules"
+            :key="index"
+            :schedule="schedule"
+            v-show="selectedScheduleIndex === index"
+          />
+        </template>
+        <Schedule v-else :schedule="scheduler"></Schedule>
 
-          <b-row>
-            <b-col>
-              <h5>CRNs: {{ selectedCrns }}</h5>
-            </b-col>
+        <b-row>
+          <b-col>
+            <h5>CRNs: {{ selectedCrns }}</h5>
+          </b-col>
 
-            <b-col md="4">
-              <button
-                id="export-ics-button"
-                class="col-auto btn-sm btn btn-primary ml-auto mb-2 mr-5 mt-1 d-block"
-                @click="exportScheduleToIcs"
-              >
-                <font-awesome-icon :icon="exportIcon" />
-                Export to ICS
-              </button>
-            </b-col>
-          </b-row>
-        </b-col>
-      </b-row>
-    </b-container>
-    <Footer
-      :semester="currentSemester"
-      @changeCurrentSemester="updateCurrentSemester"
-    />
+          <b-col md="4">
+            <button
+              id="export-ics-button"
+              class="col-auto btn-sm btn btn-primary ml-auto mb-2 mr-5 mt-1 d-block"
+              @click="exportScheduleToIcs"
+            >
+              <font-awesome-icon :icon="exportIcon" />
+              Export to ICS
+            </button>
+          </b-col>
+        </b-row>
+      </b-col>
+    </b-row>
     <b-modal
       id="courseInfoModal"
       v-if="courseInfoModalCourse"
@@ -142,7 +135,7 @@
         Close
       </b-button>
     </b-modal>
-  </div>
+  </b-container>
 </template>
 
 <script>
@@ -151,12 +144,9 @@ import NotificationsMixin from "@/mixins/NotificationsMixin";
 import ScheduleComponent from "@/components/Schedule";
 import SelectedCoursesComponent from "@/components/SelectedCourses";
 import CourseListComponent from "@/components/CourseList";
-import Footer from "@/components/Footer";
 
 import Schedule from "@/controllers/Schedule";
 import SubSemesterScheduler from "@/controllers/SubSemesterScheduler";
-
-import HeaderComponent from "@/components/Header";
 
 import {
   getSubSemesters,
@@ -165,8 +155,6 @@ import {
   removeStudentCourse,
   getStudentCourses,
 } from "@/services/YacsService";
-
-import { getDefaultSemester } from "@/services/AdminService";
 
 import { partition } from "@/utils";
 
@@ -181,8 +169,9 @@ export default {
     Schedule: ScheduleComponent,
     SelectedCourses: SelectedCoursesComponent,
     CourseList: CourseListComponent,
-    Header: HeaderComponent,
-    Footer: Footer,
+  },
+  props: {
+    currentSemester: String,
   },
   data() {
     return {
@@ -190,7 +179,6 @@ export default {
       selectedScheduleSubsemester: null,
       scheduler: new Schedule(),
       subsemesters: [],
-      currentSemester: "",
       courses: [],
       loading: false,
       exportIcon: faPaperPlane,
@@ -198,14 +186,6 @@ export default {
       courseInfoModalCourse: null,
       showCourseInfoModal: false,
     };
-  },
-  async created() {
-    const querySemester = this.$route.query.semester;
-    this.updateCurrentSemester(
-      querySemester && querySemester != "null"
-        ? querySemester
-        : await getDefaultSemester()
-    );
   },
   methods: {
     async loadStudentCourses(semester) {
@@ -398,18 +378,7 @@ export default {
           });
       }
     },
-    async updateCurrentSemester(sem) {
-      this.loading = true;
-      this.currentSemester = sem;
-      history.pushState(
-        null,
-        "",
-        encodeURI(`/?semester=${this.currentSemester}`)
-      );
-      await this.updateDataOnNewSemester();
-      await this.loadStudentCourses(this.currentSemester);
-      this.loading = false;
-    },
+
     addDays(date, days) {
       var result = new Date(date);
       result.setDate(result.getDate() + days);
@@ -598,6 +567,19 @@ export default {
     },
     numSelectedCourses() {
       return Object.values(this.selectedCourses).length;
+    },
+  },
+  watch: {
+    currentSemester: {
+      immediate: true,
+      handler(newSemester) {
+        this.loading = true;
+        history.pushState(null, "", encodeURI(`/?semester=${newSemester}`));
+
+        this.updateDataOnNewSemester()
+          .then(() => this.loadStudentCourses(newSemester))
+          .then(() => (this.loading = false));
+      },
     },
   },
 };

--- a/src/web/src/pages/Student.vue
+++ b/src/web/src/pages/Student.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <Header class="mb-3" :currentSemester="currentSemester"></Header>
-    <router-view :current-semester="currentSemester" />
+    <Header class="mb-3" :selectedSemester="selectedSemester"></Header>
+    <router-view :selected-semester="selectedSemester" />
     <Footer
-      :semester="currentSemester"
-      @changeCurrentSemester="updateCurrentSemester"
+      :selectedSemester="selectedSemester"
+      @changeSelectedSemester="updateSelectedSemester"
     />
   </div>
 </template>
@@ -22,20 +22,20 @@ export default {
   },
   data() {
     return {
-      currentSemester: "",
+      selectedSemester: "",
     };
   },
   async created() {
     const querySemester = this.$route.query.semester;
 
-    this.currentSemester =
+    this.selectedSemester =
       querySemester && querySemester != "null"
         ? querySemester
         : await getDefaultSemester();
   },
   methods: {
-    updateCurrentSemester(newSemester) {
-      this.currentSemester = newSemester;
+    updateSelectedSemester(newSemester) {
+      this.selectedSemester = newSemester;
     },
   },
 };

--- a/src/web/src/pages/Student.vue
+++ b/src/web/src/pages/Student.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <Header class="mb-3" :currentSemester="currentSemester"></Header>
+    <router-view :current-semester="currentSemester" />
+    <Footer
+      :semester="currentSemester"
+      @changeCurrentSemester="updateCurrentSemester"
+    />
+  </div>
+</template>
+
+<script>
+import HeaderComponent from "@/components/Header";
+import FooterComponent from "@/components/Footer";
+import { getDefaultSemester } from "@/services/AdminService";
+
+export default {
+  name: "StudentPage",
+  components: {
+    Header: HeaderComponent,
+    Footer: FooterComponent,
+  },
+  data() {
+    return {
+      currentSemester: "",
+    };
+  },
+  async created() {
+    const querySemester = this.$route.query.semester;
+
+    this.currentSemester =
+      querySemester && querySemester != "null"
+        ? querySemester
+        : await getDefaultSemester();
+  },
+  methods: {
+    updateCurrentSemester(newSemester) {
+      this.currentSemester = newSemester;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+footer {
+  margin: 0px !important;
+}
+</style>

--- a/src/web/src/routes.js
+++ b/src/web/src/routes.js
@@ -1,15 +1,31 @@
 import VueRouter from "vue-router";
 import AdminPage from "./pages/Admin";
-import MainPage from "./pages/Main";
+import StudentPage from "./pages/Student";
+import CourseSchedulerPage from "./pages/CourseScheduler";
 import UploadCsvPage from "./pages/UploadCsv";
 import EditSemestersPage from "./pages/EditSemesters";
+import CourseExplorerPage from "./pages/CourseExplorer";
 
 var router = new VueRouter({
   routes: [
     {
       path: "/",
-      component: MainPage,
-      name: "Schedule",
+      component: StudentPage,
+      props: true,
+      children: [
+        {
+          path: "/",
+          component: CourseSchedulerPage,
+          name: "CourseScheduler",
+          props: true,
+        },
+        {
+          path: "/explore",
+          component: CourseExplorerPage,
+          name: "CourseExplorer",
+          props: true,
+        },
+      ],
     },
     {
       path: "/Admin",

--- a/src/web/src/utils.js
+++ b/src/web/src/utils.js
@@ -18,6 +18,8 @@ export const DAY_LONGNAMES = [
   "Saturday",
 ];
 
+export const ICS_DAY_SHORTNAMES = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"];
+
 /**
  * Formats a `Date` into a readable format
  * @param {Date} date
@@ -120,3 +122,156 @@ export function partition(arr, cmpFunc = null) {
   }
   return arr;
 }
+
+export const getClosestDay = (fromDay, sessions) => {
+  if (sessions.length) {
+    sessions.sort((session1, session2) => {
+      // In DB, days are numbered MON 0 - FRI 4
+      // In JS, days are numbered SUN 0 - SAT 6
+      // Course start date will be on a week day, JS Date, Mon 1 - Fri 5
+      // Shift the JS date range back by 1
+      if (
+        Math.abs(fromDay - 1 - session1.day_of_week) <
+        Math.abs(fromDay - 1 - session2.day_of_week)
+      ) {
+        return -1;
+      } else if (
+        Math.abs(fromDay - 1 - session1.day_of_week) >
+        Math.abs(fromDay - 1 - session2.day_of_week)
+      ) {
+        return 1;
+      }
+      return 0;
+    });
+    return sessions[0].day_of_week;
+  }
+  return -1;
+};
+
+/**
+ * Checks whether `s1` spans the entire duration of `s2`
+ * @param {Subsemester} s1
+ * @param {Subsemester} s2
+ * @returns {boolean}
+ */
+export const withinDuration = (s1, s2) => {
+  return (
+    s1.date_start.getTime() <= s2.date_start.getTime() &&
+    s1.date_end.getTime() >= s2.date_end.getTime()
+  );
+};
+
+export const generateRequirementsText = (prereqs, coreqs, raw) => {
+  let text = [];
+  if (prereqs || coreqs) {
+    const same = JSON.stringify(prereqs) == JSON.stringify(coreqs);
+
+    text.push("Requires");
+
+    if (prereqs) {
+      text.push("completion of");
+
+      if (!same) text.push(prereqs.join(", "));
+    }
+
+    if (prereqs && coreqs) text.push(same ? "or" : "and");
+
+    if (coreqs) {
+      text.push("concurrent enrollment in");
+
+      text.push(coreqs.join(", "));
+    }
+  } else {
+    text.push("Requirements:", raw);
+  }
+
+  return text.join(" ");
+};
+
+export const compareSessionsByDate = (session1, session2) => {
+  let d1_s = new Date(`Sat Apr 25 2020 ${session1.time_start}`);
+  let d2_s = new Date(`Sat Apr 25 2020 ${session2.time_start}`);
+  let d1_e = new Date(`Sat Apr 25 2020 ${session1.time_end}`);
+  let d2_e = new Date(`Sat Apr 25 2020 ${session2.time_end}`);
+  if (d1_s.getTime() === d2_s.getTime() && d1_e.getTime() === d2_e.getTime()) {
+    return 0;
+  } else if (d1_s < d2_s) {
+    return -1;
+  }
+  return 1;
+};
+
+export const addDays = (date, days) => {
+  var result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+/**
+ * Export all selected course sections to ICS
+ */
+export const exportScheduleToIcs = (selectedCourses) => {
+  let calendarBuilder = window.ics();
+  let semester;
+  for (const course of selectedCourses) {
+    for (const section of course.sections.filter((s) => s.selected)) {
+      const sessionsPartitionedByStartAndEnd = partition(
+        section.sessions,
+        compareSessionsByDate
+      );
+      for (const sessionGroupOfSameMeetTime of sessionsPartitionedByStartAndEnd) {
+        const days = sessionGroupOfSameMeetTime.map(
+          (sess) => ICS_DAY_SHORTNAMES[sess.day_of_week]
+        );
+        // Gets closest day to the course start date
+        const firstDay = getClosestDay(
+          course.date_start.getDay(),
+          sessionGroupOfSameMeetTime
+        );
+        const session = sessionGroupOfSameMeetTime[0];
+        // The dates from the DB have no timezone, so when they are
+        // cast to a JS date they're by default at time midnight 00:00:00.
+        // This will exclude all classes if they're on that final day, so bump
+        // the end date by 1 day.
+        let exclusive_date_end = new Date(course.date_end);
+        exclusive_date_end.setDate(course.date_end.getDate() + 1);
+        // Moment numbers days from 0 SUN - 6 MON - 7 NEXT SUNDAY
+        // firstDay is numbered     0 MON - 4 FRI, so need to add 1 to match moment's spec
+        let dtStart = moment(course.date_start)
+          .day(firstDay + 1)
+          .toDate();
+        if (dtStart < course.date_start) {
+          // Go to NEXT week, uses the current week by default
+          dtStart = moment(course.date_start)
+            .day(firstDay + 1 + 7)
+            .toDate();
+        }
+        semester = section.semester;
+        // https://github.com/nwcell/ics.js/blob/master/ics.js#L50
+        calendarBuilder.addEvent(
+          `${course.full_title || course.title}`,
+          `${course.department}-${course.level} ${session.section}, CRN: ${session.crn}  [from YACS]`, // Add professor and type of class (LEC || LAB) to this description arg when data is available
+          "", // session.location,
+          new Date(`${dtStart.toDateString()} ${session.time_start}`),
+          new Date(`${dtStart.toDateString()} ${session.time_end}`),
+          {
+            freq: "WEEKLY",
+            interval: 1,
+            until: exclusive_date_end,
+            byday: days,
+          }
+        );
+      }
+    }
+  }
+  calendarBuilder.download(
+    `${semester.replace(/^(\w)(\w*?)\s?(\d+)/, function (
+      _,
+      semFirstLetter,
+      semRest,
+      year
+    ) {
+      return semFirstLetter.toUpperCase() + semRest.toLowerCase() + year;
+    })}_Schedule`
+  );
+};


### PR DESCRIPTION
**Issue**

Closes #160 

**Database Changes/Migrations**

N/A

**Test Modifications**

N/A

**Test Procedure**

1) Go to "/"
 Should be on `CourseScheduler`
2) Click on "Explore" link in navbar
Should be on `CourseExplorer`

**Photos**

![Screen Shot 2020-06-19 at 4 37 24 PM](https://user-images.githubusercontent.com/9285017/85185958-40f04180-b24b-11ea-9e22-28df61d1fb2c.png)


**Additional Info**

Refactored routes:
`MainPage` -> `StudentPage` for handling student interface
`StudentPage` contains nested routes for each student-side feature
- "/" (default) `CourseScheduler` previous `MainPage` 
- "/explorer" `CourseExplorer` for students to explore/find courses

Also sets the groundwork for including future routes lik
"/profile" or "/graduation", etc.
