### PR TITLE
A simple fix for web container not being able to talk to api container

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -27,8 +27,8 @@ services:
     volumes:
       - ./src/web:/app
       - web_node_modules:/app/node_modules/
-    environment: 
-      - YACS_API_HOSTNAME=http://yacs_api:5000
+    environment:
+      - YACS_API_HOST=yacs_api:5000
 
   yacs_api:
     command: python app.py

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -27,6 +27,8 @@ services:
     volumes:
       - ./src/web:/app
       - web_node_modules:/app/node_modules/
+    environment: 
+      - YACS_API_HOSTNAME=http://yacs_api:5000
 
   yacs_api:
     command: python app.py

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -28,7 +28,7 @@ services:
       - ./src/web:/app
       - web_node_modules:/app/node_modules/
     environment:
-      - YACS_API_HOST=yacs_api:5000
+      - YACS_API_HOST=http://yacs_api:5000
 
   yacs_api:
     command: python app.py

--- a/src/web/vue.config.js
+++ b/src/web/vue.config.js
@@ -6,7 +6,7 @@ module.exports = {
     disableHostCheck: true,
     proxy: {
       "/api": {
-        target: process.env.YACS_API_HOSTNAME || "http://localhost:5000",
+        target: process.env.YACS_API_HOST || "localhost:5000",
         changeOrigin: true,
         secure: false,
       },

--- a/src/web/vue.config.js
+++ b/src/web/vue.config.js
@@ -6,8 +6,9 @@ module.exports = {
     disableHostCheck: true,
     proxy: {
       "/api": {
-        target: "http://localhost:5000",
+        target: "http://yacs_api:5000",
         changeOrigin: true,
+        secure: false,
       },
     },
   },

--- a/src/web/vue.config.js
+++ b/src/web/vue.config.js
@@ -6,7 +6,7 @@ module.exports = {
     disableHostCheck: true,
     proxy: {
       "/api": {
-        target: process.env.YACS_API_HOST || "localhost:5000",
+        target: process.env.YACS_API_HOST || "http://localhost:5000",
         changeOrigin: true,
         secure: false,
       },

--- a/src/web/vue.config.js
+++ b/src/web/vue.config.js
@@ -6,7 +6,7 @@ module.exports = {
     disableHostCheck: true,
     proxy: {
       "/api": {
-        target: "http://yacs_api:5000",
+        target: process.env.YACS_API_HOSTNAME || "http://localhost:5000",
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
**Issue**

On the Windows dev environment, the web container was getting a proxy error, wasn't able to talk to the API container. 
It could not `proxy request /api/bulkCourseUpload from localhost:8080 to http://localhost:5000. (ECONNREFUSED).`

**Fix**
1. Changed the location of the API target from `http://localhost:5000` to `http://yacs_api:5000` since the NGINX set proxy_pass to that.
2. Added a `secure` field to not proxy everything to the API target.

**Additional Info**

https://medium.com/@bryantjiminson/solving-proxy-error-could-not-proxy-request-xxx-from-yyy-from-local-reactjs-app-to-nodejs-app-f28f3548afb9
