### PR TITLE
removing graduation link in header until feature is ready

### DIFF
--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -14,11 +14,6 @@
             Explore
           </router-link>
         </b-nav-item>
-        <b-nav-item>
-          <router-link :to="{ name: 'DegreeTemplates' }">
-            Graduation
-          </router-link>
-        </b-nav-item>
       </b-navbar-nav>
       <!-- If user has logged in -->
       <b-navbar-nav class="ml-auto" v-if="sessionID !== null">


### PR DESCRIPTION
**Issue**
We want to work on graduation requirements features, however, they are currently not completed.
Removing the link to the currently empty page.