### PR TITLE
Changed YACS to direct to CourseScheduler by updating Header.vue

### DIFF
--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -2,7 +2,7 @@
   <div id="header">
     <b-navbar type="light" variant="light">
       <b-navbar-brand class="logo">
-        <router-link :to="{ name: 'CourseScheduler' }">
+        <router-link class="logo" :to="{ name: 'CourseScheduler' }">
           YACS
         </router-link>
       </b-navbar-brand>
@@ -210,6 +210,8 @@ export default {
 .logo {
   font-size: 24px;
   vertical-align: middle;
+  text-decoration: none;
+  color: inherit;
 }
 
 hr {

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -210,8 +210,8 @@ export default {
 .logo {
   font-size: 24px;
   vertical-align: middle;
-  text-decoration: none;
-  color: inherit;
+  text-decoration: none !important;
+  color: inherit !important;
 }
 
 hr {

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -1,7 +1,11 @@
 <template>
   <div id="header">
     <b-navbar type="light" variant="light">
-      <b-navbar-brand class="logo" href="#">YACS</b-navbar-brand>
+      <b-navbar-brand class="logo">
+        <router-link :to="{ name: 'CourseScheduler' }">
+          YACS
+        </router-link>
+      </b-navbar-brand>
       <div class="semester">{{ selectedSemester }}</div>
       <b-navbar-nav>
         <b-nav-item>


### PR DESCRIPTION
**Issue**

This issue closes #223 

Modified and added code to change the functionality of the YACS logo to direct to CourseScheduler by adding a router-link tag before it. 

EDIT: Fixed. The Logo stays white on dark mode and black on light mode. No underlining and no blue color shift.

**Additional Info**

General project coding standards kept (in this case, two spaces per sub-line while following indents).

**Photo**

![image](https://user-images.githubusercontent.com/47283928/95810331-b2fb0380-0cde-11eb-9897-678c2cf5d860.png)
