### PR TITLE
Only run prettier formatter when pushing to master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,44 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-          ref: ${{ github.head_ref }}
-      - name: Run prettier on src/web
-        working-directory: src/web
-        run: |
-          PRETTIER_VERSION=$(cat package.json | \
-            grep \"prettier\" | \
-            tr -d '[:space:]' | \
-            awk -F: '{print substr($2, 2, length($2) - 3)}')
-
-          if ! npx prettier@$PRETTIER_VERSION "**/*.(js|vue)" --check;
-          then
-            echo "Running prettier"
-            npx prettier@$PRETTIER_VERSION "**/*.(js|vue)" --write
-
-            echo "Setting up git"
-            git config --global user.name "I'm a Github Action"
-            git config --global user.email "beepboop@github.com"
-            git remote set-url origin https://x-access-token:${{ secrets.LINT_PAT }}@github.com/${{ github.repository }}
-
-            echo "Committing changes"
-            git commit -am "beep boop Github Action Master Branch CI Prettier hard at work"
-            git push
-            echo "Changes pushed"
-
-            exit 1
-          else
-            echo "Files are clean"
-          fi
-
   backend-unit-tests:
-    needs: lint
     name: Run backend unit tests
     runs-on: ubuntu-18.04
 
@@ -100,7 +63,6 @@ jobs:
           bash <(curl -s https://codecov.io/bash)
 
   cypress:
-    needs: lint
     name: Run integration tests using cypress
     runs-on: ubuntu-latest
 
@@ -216,7 +178,6 @@ jobs:
           bash <(curl -s https://codecov.io/bash)
 
   test-build:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -226,4 +187,3 @@ jobs:
             -f docker-compose.yml \
             -f docker-compose.production.yml \
             build
-

--- a/.github/workflows/master-ci.yaml
+++ b/.github/workflows/master-ci.yaml
@@ -1,0 +1,43 @@
+name: Master CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          ref: ${{ github.head_ref }}
+      - name: Run prettier on src/web
+        working-directory: src/web
+        run: |
+          PRETTIER_VERSION=$(cat package.json | \
+            grep \"prettier\" | \
+            tr -d '[:space:]' | \
+            awk -F: '{print substr($2, 2, length($2) - 3)}')
+
+          if ! npx prettier@$PRETTIER_VERSION "**/*.(js|vue)" --check;
+          then
+            echo "Running prettier"
+            npx prettier@$PRETTIER_VERSION "**/*.(js|vue)" --write
+
+            echo "Setting up git"
+            git config --global user.name "I'm a Github Action"
+            git config --global user.email "beepboop@github.com"
+            git remote set-url origin https://x-access-token:${{ secrets.LINT_PAT }}@github.com/${{ github.repository }}
+
+            echo "Committing changes"
+            git commit -am "beep boop Github Action Master Branch CI Prettier hard at work"
+            git push
+            echo "Changes pushed"
+
+            exit 1
+          else
+            echo "Files are clean"
+          fi

--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -11,6 +11,7 @@ export default {
   name: "App",
   components: {},
   created() {
+
     if (this.$cookies.get("darkMode") == "true") {
       this.$store.commit(TOGGLE_DARK_MODE);
     }


### PR DESCRIPTION
**Issue**

N/A

**Database Changes/Migrations**

N/A

**Test Modifications**

N/A

**Test Procedure**

1. Push to master
2. Unpretty code will get prettified

**Photos**

N/A

**Additional Info**

This means for the git feature branch flow, the prettier formatter will only run when the feature is completed and merged into master. This will help people avoid having to constantly `push` and `pull` prettier changes during the feature development. 
