### PR TITLE
Postgres version -> 12 to avoid moving to 13 (new :alpine alias)

### DIFF
--- a/.github/workflows/pr-cd.yaml
+++ b/.github/workflows/pr-cd.yaml
@@ -37,7 +37,7 @@ jobs:
         id: provision
 
       - name: Share Link on PR
-        uses: thollander/actions-comment-pull-request@master
+        uses: vinodsai-a/actions-comment-pull-request@master
         with:
           message: |
             Deploy Link: ${{ steps.provision.outputs.link }}/

--- a/src/data/Dockerfile
+++ b/src/data/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:alpine
+FROM postgres:12-alpine
 # Copy schema for init
 COPY ./schema/ /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Fixes:
```
yacs_db       | 2020-10-23 16:32:31.489 UTC [1] FATAL:  database files are incompatible with server
yacs_db       | 2020-10-23 16:32:31.489 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 12, which is not compatible with this version 13.0.
yacs_db exited with code 1
```