### PR TITLE
Added modal styling to dark.scss

### DIFF
--- a/src/web/src/assets/dark.scss
+++ b/src/web/src/assets/dark.scss
@@ -150,4 +150,13 @@
   .selected {
     background-color: var(--dark-primary) !important;
   }
+  
+  .modal-header{
+    background: var(--dark-primary) !important;
+    color: var(--dark-primary-text) !important;
+  }
+  .modal-content{
+    background: var(--dark-primary) !important;
+    color: var(--dark-primary-text) !important;
+  }
 }

--- a/src/web/src/assets/dark.scss
+++ b/src/web/src/assets/dark.scss
@@ -154,6 +154,9 @@
   .modal-header{
     background: var(--dark-primary) !important;
     color: var(--dark-primary-text) !important;
+    .close{
+      color: $gray-100;
+    }
   }
   .modal-content{
     background: var(--dark-primary) !important;

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -78,11 +78,17 @@
             ref="login-modal"
             hide-footer
             title="Log In"
+            :header-close-variant="$store.state.darkMode ? 'light' : 'secondary'"
           >
             <LoginForm @submit="onLogIn()" />
           </b-modal>
 
-          <b-modal id="signup-modal" hide-footer title="Sign Up">
+          <b-modal 
+            id="signup-modal" 
+            hide-footer 
+            title="Sign Up"
+            :header-close-variant="$store.state.darkMode ? 'light' : 'secondary'"
+          >
             <SignUpForm />
           </b-modal>
         </template>

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -78,17 +78,11 @@
             ref="login-modal"
             hide-footer
             title="Log In"
-            :header-close-variant="$store.state.darkMode ? 'light' : 'secondary'"
           >
             <LoginForm @submit="onLogIn()" />
           </b-modal>
 
-          <b-modal 
-            id="signup-modal" 
-            hide-footer 
-            title="Sign Up"
-            :header-close-variant="$store.state.darkMode ? 'light' : 'secondary'"
-          >
+          <b-modal id="signup-modal" hide-footer title="Sign Up">
             <SignUpForm />
           </b-modal>
         </template>

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -93,15 +93,12 @@
         </b-row>
       </b-col>
     </b-row>
-    <!-- NOTE: Content Class Specifies The Styling For Modal In Dark Mode, -->
-    <!-- + Header-Close-Variant Specifies The Color For X Close Button.  -->
+    
     <b-modal
       id="courseInfoModal"
       v-if="courseInfoModalCourse"
       v-model="showCourseInfoModal"
       :title="courseInfoModalCourse.name + ' ' + courseInfoModalCourse.title"
-      :content-class="{ onStyleDarkMode: $store.state.darkMode }"
-      :header-close-variant="$store.state.darkMode ? 'light' : 'secondary'"
       hide-footer
       data-cy="course-info-modal"
     >


### PR DESCRIPTION
**Issue**

Closes issues #242 and #243 

**Database Changes/Migrations**

N/A

**Test Modifications**

N/A

**Test Procedure**

> 1. Launch the environment
> 2. Ensure you are in Dark Mode
> 3. Click on the Login button or the Sign up button
> 4. Ensure the modal that pops up fits the dark mode standard
> 5. Repeat steps 3&4 for the other button

**Photos**

![Light-login](https://user-images.githubusercontent.com/35609442/97364290-376e8a00-187a-11eb-9829-c03cd3c9ee8f.png)
![Dark-login](https://user-images.githubusercontent.com/35609442/97364288-376e8a00-187a-11eb-9637-b1554f4d54a8.png)

![Light-signup](https://user-images.githubusercontent.com/35609442/97364291-376e8a00-187a-11eb-9c61-7d54e7c4f32c.png)
![Dark-signup](https://user-images.githubusercontent.com/35609442/97364293-38072080-187a-11eb-8682-97d2abbb5596.png)


**Additional Info**

There might exist other modals which need the "x" to be specifically assigned colors as was done for these modals
