### PR TITLE
Fixed Reload Issue for Subject Page

### DIFF
--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -111,7 +111,7 @@ export default {
       querySemester && querySemester != "null"
         ? querySemester
         : await getDefaultSemester();
-    getCourses(this.selectedSemester).then((courses) => {
+    const courses = await getCourses(this.selectedSemester).then((courses) => {
       this.rightColumnCourses = courses.filter(
         (c) => c.department === this.subject
       );

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -111,18 +111,17 @@ export default {
       querySemester && querySemester != "null"
         ? querySemester
         : await getDefaultSemester();
-    const courses = await getCourses(this.selectedSemester).then((courses) => {
-      this.rightColumnCourses = courses.filter(
-        (c) => c.department === this.subject
-      );
-      this.leftColumnCourses = this.rightColumnCourses.splice(
-        0,
-        Math.ceil(this.rightColumnCourses.length / 2)
-      );
-      this.rightColumnCourses.splice(0, 0);
+    const courses = await getCourses(this.selectedSemester);
+    this.rightColumnCourses = courses.filter(
+      (c) => c.department === this.subject
+    );
+    this.leftColumnCourses = this.rightColumnCourses.splice(
+      0,
+      Math.ceil(this.rightColumnCourses.length / 2)
+    );
+    this.rightColumnCourses.splice(0, 0);
 
-      this.ready = true;
-    });
+    this.ready = true;
   },
   methods: {},
   computed: {},

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -78,6 +78,7 @@
 
 <script>
 import { getCourses } from "../services/YacsService";
+import { getDefaultSemester } from "@/services/AdminService";
 
 export default {
   name: "SubjectExplorer",
@@ -105,6 +106,11 @@ export default {
    * subjectCourseArr is an array of course objects
    */
   async created() {
+    const querySemester = this.$route.query.semester;
+    this.selectedSemester =
+      querySemester && querySemester != "null"
+        ? querySemester
+        : await getDefaultSemester();
     getCourses(this.selectedSemester).then((courses) => {
       this.rightColumnCourses = courses.filter(
         (c) => c.department === this.subject


### PR DESCRIPTION
**Issue**

In any subject page, the page reloads forever when refreshing.

*Example:*
> closes #248 

**Database Changes/Migrations**

N/A

*Example:*
> Added table `account_semester_selection` for a mapping from a students account and semester to a class and section (aka class/section selections)

**Test Modifications**

N/A

**Test Procedure**

Show procedure to test functionality with a clear procedure

*Example:*
> 1. Navigate to Explore page
> 2. Clicks "ARTS" button
> 3. Refresh the page
> 4. The subject page is no longer loading forever


**Additional Info**

Ike had the same issue for course explorer page and I used the same code to resolve this problem.
It happens when variable `selectedSemester` is null after refresh page, so calling `getDefaultSemester()` from `AdminService.js` is needed.
