### PR TITLE
Fixed display name to be course_name from full_name

### DIFF
--- a/src/web/src/components/CourseListing.vue
+++ b/src/web/src/components/CourseListing.vue
@@ -10,7 +10,7 @@
         {{ readableDate(course.date_end) }})
         <br />
         {{
-          course.title 
+          course.title
         }}
       </div>
       <div class="d-flex">

--- a/src/web/src/components/CourseListing.vue
+++ b/src/web/src/components/CourseListing.vue
@@ -10,7 +10,7 @@
         {{ readableDate(course.date_end) }})
         <br />
         {{
-          course.title || (course.full_title && course.full_title.toUpperCase())
+          course.title 
         }}
       </div>
       <div class="d-flex">

--- a/src/web/src/components/CourseListing.vue
+++ b/src/web/src/components/CourseListing.vue
@@ -10,7 +10,7 @@
         {{ readableDate(course.date_end) }})
         <br />
         {{
-          (course.full_title && course.full_title.toUpperCase()) || course.title
+          course.title || (course.full_title && course.full_title.toUpperCase())
         }}
       </div>
       <div class="d-flex">


### PR DESCRIPTION
**Issue**

Closes #257 

**Test Procedure**

*Example:*
> 1. Load the environment
> 2. Load spring-2021 in the admin panel
> 3. Try to schedule a topics course such as COGS 4960 or COGS 6960
> 4. See that the name on course search matches the name on the calendar matches the course name on SIS even though it's in the catalog under a different name.

**Photos**
Before:
![names-before](https://user-images.githubusercontent.com/35609442/97476211-85d86300-1924-11eb-9b34-bf63cf9c3fed.png)

Now:
![names-after](https://user-images.githubusercontent.com/35609442/97476210-85d86300-1924-11eb-9c22-98d96f488bb3.png)


**Additional Info**

N/A