### PR TITLE
User Experience Fix To Department/Major Listing Order 

### DIFF
--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -116,10 +116,7 @@ export default {
     const allTempData = courses.filter(
       (c) => c.department === this.subject
     );
-    //Initialize All Column Data To Display.
-    this.leftColumnCourses = [];
-    this.rightColumnCourses = [];
-    //Loop Through All Temp Data:
+
     for(var k=0; k<allTempData.length-1; k+=2){
       this.leftColumnCourses.push(allTempData[k]);
       this.rightColumnCourses.push(allTempData[k+1]);

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -112,17 +112,11 @@ export default {
         ? querySemester
         : await getDefaultSemester();
     const courses = await getCourses(this.selectedSemester);
-    this.rightColumnCourses = courses.filter(
+    //Obtain All Courses Such That Department Matches The Subject Name.
+    const allTempData = courses.filter(
       (c) => c.department === this.subject
     );
-    this.leftColumnCourses = this.rightColumnCourses.splice(
-      0,
-      Math.ceil(this.rightColumnCourses.length / 2)
-    );
-    this.rightColumnCourses.splice(0, 0);
-
-    const allTempData = this.leftColumnCourses.concat(this.rightColumnCourses);
-    //Reset All Column Data.
+    //Initialize All Column Data To Display.
     this.leftColumnCourses = [];
     this.rightColumnCourses = [];
     //Loop Through All Temp Data:

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -117,7 +117,7 @@ export default {
       (c) => c.department === this.subject
     );
 
-    for(var k=0; k<allTempData.length-1; k+=2){
+    for(let k=0; k<allTempData.length-1; k+=2){
       this.leftColumnCourses.push(allTempData[k]);
       this.rightColumnCourses.push(allTempData[k+1]);
     }

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -120,7 +120,7 @@ export default {
     this.leftColumnCourses = [];
     this.rightColumnCourses = [];
     //Loop Through All Temp Data:
-    for(var k=0; k<allTempData.length-1; k+=1){
+    for(var k=0; k<allTempData.length-1; k+=2){
       this.leftColumnCourses.push(allTempData[k]);
       this.rightColumnCourses.push(allTempData[k+1]);
     }

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -121,6 +121,16 @@ export default {
     );
     this.rightColumnCourses.splice(0, 0);
 
+    const allTempData = this.leftColumnCourses.concat(this.rightColumnCourses);
+    //Reset All Column Data.
+    this.leftColumnCourses = [];
+    this.rightColumnCourses = [];
+    //Loop Through All Temp Data:
+    for(var k=0; k<allTempData.length-1; k+=1){
+      this.leftColumnCourses.push(allTempData[k]);
+      this.rightColumnCourses.push(allTempData[k+1]);
+    }
+
     this.ready = true;
   },
   methods: {},


### PR DESCRIPTION
Hello Everyone!
This Is My Pull Request Concerning The Updated Listing Ordering For The Courses In The Department.
NOTE: As Opposed To Dealing W/ Bootstrap + Manually Fixing The Listing Order, It Made More Sense To Simply Change The Data That We Wanted To Display W/I Each Column. 
Below You Will Find All Important Details:

**Issue**

This Pull Request Should Ideally Close #262. 

**Full Testing Procedure**

*Sample Example(s) To Test Functionality:*
> 1. Run Development Environment w/ Loaded Fall 2020 OR Spring 2021 Semester Data.
> 2. Navigate To The Course Explore Page + Click On The CSCI Department. 
> 3. Should Be Visual Presented w/ Correct Ordering Course Displayed, w/ Lower # Courses Populated Towards The Top + Higher # Courses Populated Towards The Bottom. 


**All Relevant Photos**

Original (i.e., Currently In Master Branch):

<img width="1130" alt="Screen Shot 2020-10-30 at 13 18 35" src="https://user-images.githubusercontent.com/30516782/97736940-bf3ed900-1ab2-11eb-9388-d8d6588e59f6.png">

Final (i.e., Currently In DepartListingOrder Branch): 

<img width="1152" alt="Screen Shot 2020-10-30 at 13 18 57" src="https://user-images.githubusercontent.com/30516782/97736894-b3ebad80-1ab2-11eb-948a-d24346f2e736.png">
