### PR TITLE
Fixed top spacing for header and course listing grid on Explore page

### DIFF
--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -135,7 +135,7 @@ export default {
 
 <style>
 .gridContainer {
-  margin-top: 30px;
+  margin-top: 40px;
   display: inline-grid;
   grid-template-columns: auto auto;
   justify-content: center;

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -135,7 +135,7 @@ export default {
 
 <style>
 .gridContainer {
-  margin-top: 40px;
+  margin-top: 25px;
   display: inline-grid;
   grid-template-columns: auto auto;
   justify-content: center;

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -135,6 +135,7 @@ export default {
 
 <style>
 .gridContainer {
+  margin-top: 30px;
   display: inline-grid;
   grid-template-columns: auto auto;
   justify-content: center;


### PR DESCRIPTION
**Issue**

Closes "UX Bug - Explore Main - Top Spacing" #260


**Database Changes/Migrations**

N/A


**Test Modifications**

N/A

**Test Procedure**

Show procedure to test functionality with a clear procedure

1. Navigate to Explorer page
2. The space between header and department listing grids increased, visual effect is more perceivable under dark mode.

**Photos**

Show before and after, capture screenshot/gif of finished feature/bug

**Additional Info**
Before

![image](https://user-images.githubusercontent.com/43757365/97761541-2fedf180-1ac3-11eb-9bfc-9caedb46ba9a.png)

After

![image](https://user-images.githubusercontent.com/43757365/97761498-1482e680-1ac3-11eb-98c0-da564b85ec30.png)

