### PR TITLE
Docker compose fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: "3.4"
 
 # web (front-end) depends on api (back-end) depends on (db)
 # web -> api -> db [dependency chain]
@@ -6,6 +6,7 @@ version: '3.4'
 
 services:
   yacs_web:
+    restart: unless-stopped
     container_name: yacs_web # makes logs nicer, otherwise would be yacs_web_1, but is yacs_web
     build:
       context: ./src/web
@@ -14,7 +15,7 @@ services:
       - yacs_api
 
   yacs_api:
-    restart: always
+    restart: unless-stopped
     container_name: yacs_api
     build:
       context: ./src/api/
@@ -23,6 +24,7 @@ services:
       - yacs_db
 
   yacs_db:
+    restart: unless-stopped
     container_name: yacs_db
     build:
       context: ./src/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
   yacs_api:
     restart: unless-stopped
     container_name: yacs_api
+    stdin_open: true
+    tty: true
     build:
       context: ./src/api/
       dockerfile: Dockerfile


### PR DESCRIPTION
1. `restart-always` meant the `yacs_api` kept restarting after `ctrl+c` stopping the dev compose
2. python has trouble with flushing stdout when run in docker but `stdin_open` and `tty` seems to do the trick