### PR TITLE
rollback on db error

### DIFF
--- a/src/api/db/connection.py
+++ b/src/api/db/connection.py
@@ -9,9 +9,9 @@ DB_HOST = os.environ.get('DB_HOST', 'localhost')
 DB_PORT = os.environ.get('DB_PORT', None)
 DB_PASS = os.environ.get('DB_PASS', None)
 
+
 class database():
     def connect(self):
-        # if we cannot connect to db, then app is useless, so better crash, don't catch error here.
         self.conn = psycopg2.connect(
             dbname=DB_NAME,
             user=DB_USER,
@@ -39,6 +39,8 @@ class database():
         except psycopg2.Error as e:
             print("DATABASE ERROR: ", end="")
             print(e)
+            self.conn.close()
+            self.connect()
             return (ret, e)
 
         return (ret, None)

--- a/src/api/db/connection.py
+++ b/src/api/db/connection.py
@@ -39,8 +39,7 @@ class database():
         except psycopg2.Error as e:
             print("DATABASE ERROR: ", end="")
             print(e)
-            self.conn.close()
-            self.connect()
+            self.conn.rollback()
             return (ret, e)
 
         return (ret, None)


### PR DESCRIPTION
**Issue**
Used to hang on incomplete/err transaction:

Prior Error Logs with Hang:
```
yacs_api      | 172.20.0.5 - - [07/Nov/2020 16:03:15] "GET /api/error HTTP/1.0" 200 -
yacs_nginx    | 172.20.0.1 - - [07/Nov/2020:16:03:15 +0000] "GET /api/error HTTP/1.1" 200 116 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0" "-"
yacs_db       | 2020-11-07 16:03:16.628 UTC [49] ERROR:  current transaction is aborted, commands ignored until end of transaction block
yacs_db       | 2020-11-07 16:03:16.628 UTC [49] STATEMENT:  select * from a_table_that_doesnt_exist;
yacs_api      | DATABASE ERROR: current transaction is aborted, commands ignored until end of transaction block
yacs_api      |
yacs_api      | 172.20.0.5 - - [07/Nov/2020 16:03:16] "GET /api/error HTTP/1.0" 200 -
yacs_nginx    | 172.20.0.1 - - [07/Nov/2020:16:03:16 +0000] "GET /api/error HTTP/1.1" 200 116 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0" "-"
yacs_db       | 2020-11-07 16:03:17.015 UTC [49] ERROR:  current transaction is aborted, commands ignored until end of transaction block
yacs_db       | 2020-11-07 16:03:17.015 UTC [49] STATEMENT:  select * from a_table_that_doesnt_exist;
yacs_api      | DATABASE ERROR: current transaction is aborted, commands ignored until end of transaction block
yacs_api      |
yacs_api      | 172.20.0.5 - - [07/Nov/2020 16:03:17] "GET /api/error HTTP/1.0" 200 -
yacs_nginx    | 172.20.0.1 - - [07/Nov/2020:16:03:17 +0000] "GET /api/error HTTP/1.1" 200 116 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0" "-"
yacs_db       | 2020-11-07 16:03:17.424 UTC [49] ERROR:  current transaction is aborted, commands ignored until end of transaction block
```

New Error Logs without Hang:
```
yacs_api      | [INFO] Database Connected
yacs_api      | 172.20.0.5 - - [07/Nov/2020 16:03:01] "GET /api/error HTTP/1.0" 200 -
yacs_nginx    | 172.20.0.1 - - [07/Nov/2020:16:03:01 +0000] "GET /api/error HTTP/1.1" 200 155 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0" "-"
yacs_db       | 2020-11-07 16:03:01.726 UTC [44] ERROR:  relation "a_table_that_doesnt_exist" does not exist at character 15
yacs_db       | 2020-11-07 16:03:01.726 UTC [44] STATEMENT:  select * from a_table_that_doesnt_exist;
yacs_api      | DATABASE ERROR: relation "a_table_that_doesnt_exist" does not exist
yacs_api      | LINE 1: select * from a_table_that_doesnt_exist;
yacs_api      |                       ^
yacs_api      |
yacs_api      | [INFO] Database Connected
yacs_api      | 172.20.0.5 - - [07/Nov/2020 16:03:01] "GET /api/error HTTP/1.0" 200 -
yacs_nginx    | 172.20.0.1 - - [07/Nov/2020:16:03:01 +0000] "GET /api/error HTTP/1.1" 200 155 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0" "-"
yacs_db       | 2020-11-07 16:03:02.222 UTC [45] ERROR:  relation "a_table_that_doesnt_exist" does not exist at character 15
yacs_db       | 2020-11-07 16:03:02.222 UTC [45] STATEMENT:  select * from a_table_that_doesnt_exist;
yacs_api      | DATABASE ERROR: relation "a_table_that_doesnt_exist" does not exist
yacs_api      | LINE 1: select * from a_table_that_doesnt_exist;
yacs_api      |                       ^
yacs_api      |
yacs_api      | [INFO] Database Connected
yacs_api      | 172.20.0.5 - - [07/Nov/2020 16:03:02] "GET /api/error HTTP/1.0" 200 -
yacs_nginx    | 172.20.0.1 - - [07/Nov/2020:16:03:02 +0000] "GET /api/error HTTP/1.1" 200 155 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0" "-"
yacs_db       | 2020-11-07 16:03:02.710 UTC [46] ERROR:  relation "a_table_that_doesnt_exist" does not exist at character 15
yacs_db       | 2020-11-07 16:03:02.710 UTC [46] STATEMENT:  select * from a_table_that_doesnt_exist;
yacs_api      | DATABASE ERROR: relation "a_table_that_doesnt_exist" does not exist
yacs_api      | LINE 1: select * from a_table_that_doesnt_exist;
```

To test I added sample route to /src/api/app.py under `/api/error` to force a db error
```py
  @app.route('/api/error')
  def broken_query():
      res = db_conn.execute('select * from a_table_that_doesnt_exist;', (), True)
      return Response(str(res))
```
