### PR TITLE
add SelectedCoursesCookie controller to persist schedules for anonymous users

### DIFF
--- a/src/web/src/controllers/SelectedCoursesCookie.js
+++ b/src/web/src/controllers/SelectedCoursesCookie.js
@@ -1,0 +1,144 @@
+import "@/typedef";
+
+// eslint-disable-next-line no-unused-vars
+import { VueCookies } from "vue-cookies";
+
+const COOKIE_KEY = "selectedCourses";
+
+class SelectedCoursesCookie {
+  /**
+   * @typedef SelectedCourse
+   * @property {string} id
+   * @property {string[]} selectedSectionCrns
+   *
+   * @typedef SelectedSemesters
+   * @type {{[semester: string]: SelectedCourse[]}}
+   */
+
+  /**
+   * @param {VueCookies} $cookies
+   * @param {SelectedCourse[]} selectedCourses
+   * @private
+   */
+  constructor($cookies, selectedSemesters) {
+    /**
+     * @type {VueCookies}
+     * @private
+     */
+    this.$cookies = $cookies;
+    /**
+     * @type {SelectedSemesters}
+     * @private
+     */
+    this.selectedSemesters = selectedSemesters;
+  }
+
+  /**
+   *
+   * @param {VueCookies} $cookies
+   * @returns {null|SelectedCoursesCookie}
+   */
+  static load($cookies) {
+    return new SelectedCoursesCookie(
+      $cookies,
+      $cookies.isKey(COOKIE_KEY) ? $cookies.get(COOKIE_KEY) : {}
+    );
+  }
+
+  save() {
+    this.$cookies.set(COOKIE_KEY, this.selectedSemesters);
+    console.log(JSON.stringify(this.selectedSemesters, undefined, 2));
+  }
+
+  /**
+   *
+   * @param {string} semester
+   * @returns {SelectedCourse[]}
+   */
+  getSelectedCourses(semester) {
+    if (this.selectedSemesters[semester] === undefined) {
+      this.selectedSemesters[semester] = [];
+    }
+
+    return this.selectedSemesters[semester];
+  }
+
+  /**
+   * @param {string} semester
+   * @param {string} id
+   * @returns {Course}
+   */
+  getSelectedCourse(semester, id) {
+    const selectedCourses = this.getSelectedCourses(semester);
+
+    const selectedCourse = selectedCourses.find(
+      (selectedCourse) => selectedCourse.id === id
+    );
+
+    if (selectedCourse === undefined) {
+      const newSelectedCourse = { id, selectedSectionCrns: [] };
+
+      selectedCourses.push(newSelectedCourse);
+
+      return newSelectedCourse;
+    } else {
+      return selectedCourse;
+    }
+  }
+
+  /**
+   * Only adds an entry for the course, to add sections, call `addCourseSection`
+   * @param {string} semester
+   * @param {Course} course
+   */
+  addCourse(semester, course) {
+    this.getSelectedCourse(semester, course.id);
+
+    return this;
+  }
+
+  /**
+   * @param {string} semester
+   * @param {Course} course
+   * @param {CourseSection} section
+   */
+  addCourseSection(semester, course, section) {
+    this.getSelectedCourse(semester, course.id).selectedSectionCrns.push(
+      section.crn
+    );
+    return this;
+  }
+
+  /**
+   * @param {string} semester
+   * @param {Course} course
+   */
+  removeCourse(semester, course) {
+    this.selectedSemesters[semester] = this.getSelectedCourses(semester).filter(
+      (selectedCourse) => selectedCourse.id !== course.id
+    );
+
+    return this;
+  }
+
+  /**
+   *
+   * @param {string} semester
+   * @param {CourseSection} section
+   */
+  removeCourseSection(semester, section) {
+    const selectedCourse = this.getSelectedCourses(
+      semester
+    ).find((selectedCourse) =>
+      selectedCourse.selectedSectionCrns.some((crn) => crn === section.crn)
+    );
+
+    selectedCourse.selectedSectionCrns = selectedCourse.selectedSectionCrns.filter(
+      (crn) => crn !== section.crn
+    );
+
+    return this;
+  }
+}
+
+export { SelectedCoursesCookie };

--- a/src/web/src/controllers/SelectedCoursesCookie.js
+++ b/src/web/src/controllers/SelectedCoursesCookie.js
@@ -47,7 +47,6 @@ class SelectedCoursesCookie {
 
   save() {
     this.$cookies.set(COOKIE_KEY, this.selectedSemesters);
-    console.log(JSON.stringify(this.selectedSemesters, undefined, 2));
   }
 
   /**

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -248,26 +248,34 @@ export default {
       } else if (!this.userId) {
         const selectedCoursesCookie = SelectedCoursesCookie.load(this.$cookies);
 
-        selectedCoursesCookie
-          .getSelectedCourses(semester)
-          .forEach((selectedCourse) => {
-            const course = this.courses.find(
-              (course) => course.id === selectedCourse.id
-            );
-
-            course.selected = true;
-            this.$set(this.selectedCourses, course.id, course);
-            this.scheduler.addCourse(course);
-
-            selectedCourse.selectedSectionCrns.forEach((selectedSectionCrn) => {
-              const section = course.sections.find(
-                (section) => section.crn === selectedSectionCrn
+        try {
+          selectedCoursesCookie
+            .semester(this.selectedSemester)
+            .selectedCourses.forEach((selectedCourse) => {
+              const course = this.courses.find(
+                (course) => course.id === selectedCourse.id
               );
 
-              section.selected = true;
-              this.scheduler.addCourseSection(course, section);
+              course.selected = true;
+              this.$set(this.selectedCourses, course.id, course);
+              this.scheduler.addCourse(course);
+
+              selectedCourse.selectedSectionCrns.forEach(
+                (selectedSectionCrn) => {
+                  const section = course.sections.find(
+                    (section) => section.crn === selectedSectionCrn
+                  );
+
+                  section.selected = true;
+                  this.scheduler.addCourseSection(course, section);
+                }
+              );
             });
-          });
+        } catch (err) {
+          // If there is an error here, it might mean the data was changed,
+          //  thus we need to reload the cookie
+          selectedCoursesCookie.clear().save();
+        }
       }
     },
     updateDataOnNewSemester() {
@@ -346,7 +354,8 @@ export default {
           });
       } else {
         SelectedCoursesCookie.load(this.$cookies)
-          .addCourse(this.selectedSemester, course)
+          .semester(this.selectedSemester)
+          .addCourse(course)
           .save();
       }
     },
@@ -372,7 +381,8 @@ export default {
           });
       } else {
         SelectedCoursesCookie.load(this.$cookies)
-          .addCourseSection(this.selectedSemester, course, section)
+          .semester(this.selectedSemester)
+          .addCourseSection(course, section)
           .save();
       }
     },
@@ -413,7 +423,10 @@ export default {
             console.log(error.response);
           });
       } else {
-        SelectedCoursesCookie.load(this.$cookies).removeCourse(course).save();
+        SelectedCoursesCookie.load(this.$cookies)
+          .semester(this.selectedSemester)
+          .removeCourse(course)
+          .save();
       }
     },
     removeCourseSection(section) {
@@ -437,7 +450,8 @@ export default {
           });
       } else {
         SelectedCoursesCookie.load(this.$cookies)
-          .removeCourseSection(this.selectedSemester, section)
+          .semester(this.selectedSemester)
+          .removeCourseSection(section)
           .save();
       }
     },

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -247,7 +247,7 @@ export default {
         }
       } else if (!this.userId) {
         const selectedCoursesCookie = SelectedCoursesCookie.load(this.$cookies);
-        console.log(selectedCoursesCookie.getSelectedCourses(semester));
+
         selectedCoursesCookie
           .getSelectedCourses(semester)
           .forEach((selectedCourse) => {

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -214,37 +214,31 @@ export default {
       this.userID = this.$cookies.get("userID");
 
       if (this.userID) {
-        console.log("Loading user courses...");
-        try {
-          const info = { uid: this.userID };
-          var cids = await getStudentCourses(info);
-          console.log(cids);
+        const info = { uid: this.userID };
+        var cids = await getStudentCourses(info);
 
-          cids.forEach((cid) => {
-            if (cid.semester == this.selectedSemester) {
-              var c = this.courses.find(function (course) {
-                return (
-                  course.name == cid.course_name &&
-                  course.semester == cid.semester
-                );
+        cids.forEach((cid) => {
+          if (cid.semester == this.selectedSemester) {
+            var c = this.courses.find(function (course) {
+              return (
+                course.name == cid.course_name &&
+                course.semester == cid.semester
+              );
+            });
+
+            if (cid.crn != "-1") {
+              var sect = c.sections.find(function (section) {
+                return section.crn == cid.crn;
               });
-
-              if (cid.crn != "-1") {
-                var sect = c.sections.find(function (section) {
-                  return section.crn == cid.crn;
-                });
-                sect.selected = true;
-                this.scheduler.addCourseSection(c, sect);
-              } else {
-                c.selected = true;
-                this.$set(this.selectedCourses, c.id, c);
-                this.scheduler.addCourse(c);
-              }
+              sect.selected = true;
+              this.scheduler.addCourseSection(c, sect);
+            } else {
+              c.selected = true;
+              this.$set(this.selectedCourses, c.id, c);
+              this.scheduler.addCourse(c);
             }
-          });
-        } catch (error) {
-          console.log(error);
-        }
+          }
+        });
       } else if (!this.userId) {
         const selectedCoursesCookie = SelectedCoursesCookie.load(this.$cookies);
 
@@ -337,21 +331,12 @@ export default {
       this.scheduler.addCourse(course);
 
       if (this.userID) {
-        const info = {
+        addStudentCourse({
           name: course.name,
           semester: this.selectedSemester,
           uid: this.userID,
           cid: "-1",
-        };
-
-        addStudentCourse(info)
-          .then((response) => {
-            console.log(`Saved ${course.name}`);
-            console.log(response);
-          })
-          .catch((error) => {
-            console.log(error.response);
-          });
+        });
       } else {
         SelectedCoursesCookie.load(this.$cookies)
           .semester(this.selectedSemester)
@@ -364,21 +349,12 @@ export default {
       section.selected = true;
 
       if (this.userID) {
-        const info = {
+        addStudentCourse({
           name: course.name,
           semester: this.selectedSemester,
           uid: this.userID,
           cid: section.crn,
-        };
-
-        addStudentCourse(info)
-          .then((response) => {
-            console.log(`Saved section ${section.crn}`);
-            console.log(response);
-          })
-          .catch((error) => {
-            console.log(error.response);
-          });
+        });
       } else {
         SelectedCoursesCookie.load(this.$cookies)
           .semester(this.selectedSemester)
@@ -407,21 +383,12 @@ export default {
       this.scheduler.removeAllCourseSections(course);
 
       if (this.userID) {
-        const info = {
+        removeStudentCourse({
           name: course.name,
           semester: this.selectedSemester,
           uid: this.userID,
           cid: null,
-        };
-
-        removeStudentCourse(info)
-          .then((response) => {
-            console.log(`Unsaved ${course.name}`);
-            console.log(response);
-          })
-          .catch((error) => {
-            console.log(error.response);
-          });
+        });
       } else {
         SelectedCoursesCookie.load(this.$cookies)
           .semester(this.selectedSemester)
@@ -431,23 +398,14 @@ export default {
     },
     removeCourseSection(section) {
       this.scheduler.removeCourseSection(section);
+
       if (this.userID) {
-        var name = section.department + "-" + section.level;
-        const info = {
-          name: name,
+        removeStudentCourse({
+          name: section.department + "-" + section.level,
           semester: this.selectedSemester,
           uid: this.userID,
           cid: section.crn,
-        };
-
-        removeStudentCourse(info)
-          .then((response) => {
-            console.log(`Unsaved section ${section.crn}!`);
-            console.log(response);
-          })
-          .catch((error) => {
-            console.log(error.response);
-          });
+        });
       } else {
         SelectedCoursesCookie.load(this.$cookies)
           .semester(this.selectedSemester)


### PR DESCRIPTION
**Issue**

Closes #210 

**Database Changes/Migrations**

N/A

**Test Modifications**

N/A

**Test Procedure**
Persist in reloads
1. Load CourseScheduler page
2. Select a course
3. Reload the page
    1. The previous course should be selected and section should be selected
4. Switch to different semester and back
    1. The previous course should be selected and section should be selected

**Photos**

N/A

**Additional Info**

N/A
