### PR TITLE
Fix Dark Selected Courses

### DIFF
--- a/src/web/src/components/CourseListing.vue
+++ b/src/web/src/components/CourseListing.vue
@@ -60,7 +60,11 @@
                 : $store.state.darkMode
                 ? 'var(--dark-primary)'
                 : 'white',
-              color: 'black',
+              'color': section.selected 
+                ? 'black' 
+                : $store.state.darkMode
+                ? 'var(--dark-primary-text)'
+                : 'black',
             }"
           >
             <b-row class="mb-2" align-h="between">

--- a/src/web/src/components/CourseListing.vue
+++ b/src/web/src/components/CourseListing.vue
@@ -57,10 +57,10 @@
                 : 'none',
               'background-color': section.selected
                 ? `${getBackgroundColor(section)} !important`
-                : `${$store.state.darkMode}`
+                : $store.state.darkMode
                 ? 'var(--dark-primary)'
                 : 'white',
-              color: section.selected ? 'black' : 'var(--dark-text-primary)',
+              color: 'black',
             }"
           >
             <b-row class="mb-2" align-h="between">


### PR DESCRIPTION
Hello Everyone!
This Is My Pull Request Concerning The Adjustments For The Selected Courses Listings In Dark Mode.
Below You Will Find All Important Details:

**Issue**

This Pull Request Should Ideally Close #368 . 

**Database Changes/Migrations**

Not Applicable.

**Full Testing Procedure**

*Sample Example(s) To Test Functionality:*
> 1. Run Spring 2021 w/ YACS + Select Some Courses Such As Data Structures w/ Multiple Sections.
> 2. Navigate To The Selected Courses Tab. 
> 3. Should Immediately See Corrected Styling w/ Dark Mode On + Dark Mode Off. 

**All Relevant Screenshots**

Before (i.e., Same From Issue): 

![compare-dark1](https://user-images.githubusercontent.com/35609442/101206088-a048df00-363c-11eb-827d-dfd4e348d832.png)
![bad-dark1](https://user-images.githubusercontent.com/35609442/101206106-a6d75680-363c-11eb-9d72-39728ddbde8a.png)
![bad-dark2](https://user-images.githubusercontent.com/35609442/101206108-a76fed00-363c-11eb-8022-ffe0aabec379.png)

After: 

<img width="377" alt="Screen Shot 2020-12-06 at 08 23 32" src="https://user-images.githubusercontent.com/30516782/101281374-8aeac680-379c-11eb-8300-0b9a59e3f001.png">
<img width="1240" alt="Screen Shot 2020-12-06 at 08 24 43" src="https://user-images.githubusercontent.com/30516782/101281375-8d4d2080-379c-11eb-9f8e-9254445d47cb.png">
<img width="372" alt="Screen Shot 2020-12-06 at 08 23 39" src="https://user-images.githubusercontent.com/30516782/101281376-8f16e400-379c-11eb-893a-72eb53dd1cef.png">
<img width="1235" alt="Screen Shot 2020-12-06 at 08 24 52" src="https://user-images.githubusercontent.com/30516782/101281382-91793e00-379c-11eb-95fe-28417252107f.png">
