### PR TITLE
production CD with self-hosted github runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,17 @@ jobs:
             -f docker-compose.yml \
             -f docker-compose.production.yml \
             build
+
+  publish-action-status:
+    needs: [backend-unit-tests, test-build]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: technote-space/workflow-conclusion-action@v1
+      - name: Publish status checks
+        uses: LouisBrunner/checks-action@v0.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: CI
+          conclusion: ${{ env.WORKFLOW_CONCLUSION }}

--- a/.github/workflows/master-ci.yaml
+++ b/.github/workflows/master-ci.yaml
@@ -41,3 +41,17 @@ jobs:
           else
             echo "Files are clean"
           fi
+
+  publish-action-status:
+    needs: [prettier]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: technote-space/workflow-conclusion-action@v1
+      - name: Publish status checks
+        uses: LouisBrunner/checks-action@v0.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Master CI
+          conclusion: ${{ env.WORKFLOW_CONCLUSION }}

--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -11,9 +11,36 @@ jobs:
     runs-on: [self-hosted, rpi, prod]
 
     steps:
+      # - uses: fountainhead/action-wait-for-check@v1.0.0
+      #   id: wait-for-ci
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     checkName: CI
+
+      # - name: Check if ci was successful
+      #   if: steps.wait-for-ci.outputs.conclusion != 'success'
+      #   run: exit 1
+
+      # - uses: fountainhead/action-wait-for-check@v1.0.0
+      #   id: wait-for-master-ci
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     checkName: Master CI
+
+      # - name: Check if ci was successful
+      #   if: steps.wait-for-master-ci.outputs.conclusion != 'success'
+      #   run: exit 1
+
       - uses: actions/checkout@v2
         with:
           ref: master
+
+      - name: Copy certificates into yacs_web
+        run: cp ~/yacs.n/src/web/cert/yacs.cs.rpi.edu* .
+        working-directory: src/web/cert
+
+      - name: Test environment variables
+        run: echo $HOST
 
       - name: Build images
         run: |

--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -1,0 +1,31 @@
+name: Production CD
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - prod_cd
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, rpi, prod]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: Build images
+        run: |
+          docker-compose -f docker-compose.yml -f docker-compose.production.yml build yacs_api yacs_web
+
+      # - name: Update yacs_api
+      #   run: |
+      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml stop yacs_api &&
+      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml rm -f yacs_api &&
+      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_api
+
+      # - name: Update yacs_web
+      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml stop yacs_web &&
+      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml rm -f yacs_web &&
+      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_web

--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - prod_cd
+      - master
 
 jobs:
   deploy:
@@ -18,25 +18,25 @@ jobs:
       API_WORKERS: 8
 
     steps:
-      # - uses: fountainhead/action-wait-for-check@v1.0.0
-      #   id: wait-for-ci
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     checkName: CI
+      - uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-ci
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: CI
 
-      # - name: Check if ci was successful
-      #   if: steps.wait-for-ci.outputs.conclusion != 'success'
-      #   run: exit 1
+      - name: Check if ci was successful
+        if: steps.wait-for-ci.outputs.conclusion != 'success'
+        run: exit 1
 
-      # - uses: fountainhead/action-wait-for-check@v1.0.0
-      #   id: wait-for-master-ci
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     checkName: Master CI
+      - uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-master-ci
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Master CI
 
-      # - name: Check if ci was successful
-      #   if: steps.wait-for-master-ci.outputs.conclusion != 'success'
-      #   run: exit 1
+      - name: Check if ci was successful
+        if: steps.wait-for-master-ci.outputs.conclusion != 'success'
+        run: exit 1
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -46,20 +46,17 @@ jobs:
         run: cp ~/yacs.n/src/web/cert/yacs.cs.rpi.edu* .
         working-directory: src/web/cert
 
-      - name: Test environment variables
-        run: echo $API_WORKERS
-
       - name: Build images
         run: |
           docker-compose -f docker-compose.yml -f docker-compose.production.yml build yacs_api yacs_web
 
-      # - name: Update yacs_api
-      #   run: |
-      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml stop yacs_api &&
-      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml rm -f yacs_api &&
-      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_api
+      - name: Update yacs_api
+        run: |
+          docker-compose -f docker-compose.yml -f docker-compose.production.yml stop yacs_api &&
+          docker-compose -f docker-compose.yml -f docker-compose.production.yml rm -f yacs_api &&
+          docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_api
 
-      # - name: Update yacs_web
-      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml stop yacs_web &&
-      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml rm -f yacs_web &&
-      #     docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_web
+      - name: Update yacs_web
+          docker-compose -f docker-compose.yml -f docker-compose.production.yml stop yacs_web &&
+          docker-compose -f docker-compose.yml -f docker-compose.production.yml rm -f yacs_web &&
+          docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_web

--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     runs-on: [self-hosted, rpi, prod]
-    environment: yacs-prod
+    environment: yacs-rpi-prod
 
     env:
       HOST: ${{ secrets.HOST }}

--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -9,6 +9,13 @@ on:
 jobs:
   deploy:
     runs-on: [self-hosted, rpi, prod]
+    environment: yacs-prod
+
+    env:
+      HOST: ${{ secrets.HOST }}
+      ADMIN_PASS: ${{ secrets.ADMIN_PASS }}
+      DB_PASS: ${{ secrets.DB_PASS }}
+      API_WORKERS: 8
 
     steps:
       # - uses: fountainhead/action-wait-for-check@v1.0.0
@@ -40,7 +47,7 @@ jobs:
         working-directory: src/web/cert
 
       - name: Test environment variables
-        run: echo $HOST
+        run: echo $API_WORKERS
 
       - name: Build images
         run: |

--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -57,6 +57,7 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_api
 
       - name: Update yacs_web
+        run: |
           docker-compose -f docker-compose.yml -f docker-compose.production.yml stop yacs_web &&
           docker-compose -f docker-compose.yml -f docker-compose.production.yml rm -f yacs_web &&
           docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d yacs_web


### PR DESCRIPTION
I've setup a self-hosted Github Action runner on the production VM so we can finally do CD through Github Actions.

The `prod-cd` workflow runs on master push or manual trigger. It uses the `yacs-prod` environment which contains the secrets for prod as well as configuration for manual verification of deployment. I've currently configured it such that deployments require manual approval (by me for now).

The `prod-cd` workflow will pull the new code from master, rebuild and restart `yacs_api` and `yacs_web` in the correct order. 

I've done some quick tests, you can go back in the commits or actions history to see the workflow in action. 

TLDR; CD process = push to master -> create new deployment -> manual approve -> redeploy production