### PR TITLE
Linked Course Names

### DIFF
--- a/src/web/src/components/ScheduleEvent.vue
+++ b/src/web/src/components/ScheduleEvent.vue
@@ -1,7 +1,7 @@
 <template functional>
   <div class="schedule-event" :style="data.style" data-cy="schedule-event">
     <div class="event-text">
-      <span data-cy="title"> <a v-bind:href= "'/explore/' + props.name.split(' ')[0] + '/' + props.name.split(' ')[0] + '-' + props.name.split(' ')[1]"> {{props.title}}</a> </span>
+      <span data-cy="title"> <a v-bind:href= $options.getExploreCourseLink(props.name)> {{props.title}}</a> </span>
       <br />
       <span data-cy="name">{{ props.name }}</span>
       &nbsp;-&nbsp;
@@ -15,6 +15,15 @@
     </div>
   </div>
 </template>
+<script>
+export default {
+  getExploreCourseLink(courseName) {
+    var subject = courseName.split(' ')[0];
+    var courseNumber = courseName.split(' ')[1];
+    return "/explore/" + subject + "/" + subject + "-" + courseNumber;
+  },
+};
+</script>
 <style lang="scss">
 .schedule-event {
   display: block;
@@ -41,3 +50,4 @@
   }
 }
 </style>
+

--- a/src/web/src/components/ScheduleEvent.vue
+++ b/src/web/src/components/ScheduleEvent.vue
@@ -20,7 +20,7 @@ export default {
   getExploreCourseLink(courseName) {
     var subject = courseName.split(' ')[0];
     var courseNumber = courseName.split(' ')[1];
-    return "/explore/" + subject + "/" + subject + "-" + courseNumber;
+    return `/explore/${subject}/${subject}-${courseNumber}`;
   },
 };
 </script>

--- a/src/web/src/components/ScheduleEvent.vue
+++ b/src/web/src/components/ScheduleEvent.vue
@@ -1,7 +1,7 @@
 <template functional>
   <div class="schedule-event" :style="data.style" data-cy="schedule-event">
     <div class="event-text">
-      <span data-cy="title">{{ props.title }}</span>
+      <span data-cy="title"> <a v-bind:href= "'/explore/' + props.name.split(' ')[0] + '/' + props.name.split(' ')[0] + '-' + props.name.split(' ')[1]"> {{props.title}}</a> </span>
       <br />
       <span data-cy="name">{{ props.name }}</span>
       &nbsp;-&nbsp;


### PR DESCRIPTION
**Issue 378**

This Pull Request closes issue 378, which was a feature request to make the schedule event course name a clickable link. The link brings the user to the explore page for the given course.

*Example:*
> closes #378 

**Database Changes/Migrations**
None
