### PR TITLE
Nginx cache Solution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     build:
       context: ./src/web
       dockerfile: Dockerfile
+      args:
+        ENABLED_MODULES: brotli
     depends_on:
       - yacs_api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     build:
       context: ./src/web
       dockerfile: Dockerfile
-      args:
-        ENABLED_MODULES: brotli
     depends_on:
       - yacs_api
 

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -7,7 +7,70 @@ COPY ./ .
 FROM develop-stage as build-stage
 RUN npm run build
 
-FROM nginx as production-stage
+
+FROM nginx:mainline as builder
+
+ARG ENABLED_MODULES
+
+RUN set -ex \
+  && if [ "$ENABLED_MODULES" = "" ]; then \
+  echo "No additional modules enabled, exiting"; \
+  exit 1; \
+  fi
+
+COPY ./ /modules/
+
+RUN set -ex \
+  && apt update \
+  && apt install -y --no-install-suggests --no-install-recommends \
+  patch make wget mercurial devscripts debhelper dpkg-dev \
+  quilt lsb-release build-essential libxml2-utils xsltproc \
+  equivs git g++ \
+  && hg clone https://hg.nginx.org/pkg-oss/ \
+  && cd pkg-oss \
+  && mkdir /tmp/packages \
+  && for module in $ENABLED_MODULES; do \
+    echo "Building $module for nginx-$NGINX_VERSION"; \
+    if [ -d /modules/$module ]; then \
+      echo "Building $module from user-supplied sources"; \
+      # check if module sources file is there and not empty
+      if [ ! -s /modules/$module/source ]; then \
+        echo "No source file for $module in modules/$module/source, exiting"; \
+        exit 1; \
+      fi; \
+      # some modules require build dependencies
+      if [ -f /modules/$module/build-deps ]; then \
+        echo "Installing $module build dependencies"; \
+        apt update && apt install -y --no-install-suggests --no-install-recommends $(cat /modules/$module/build-deps | xargs); \
+      fi; \
+      # if a module has a build dependency that is not in a distro, provide a
+      # shell script to fetch/build/install those
+      # note that shared libraries produced as a result of this script will
+      # not be copied from the builder image to the main one so build static
+      if [ -x /modules/$module/prebuild ]; then \
+        echo "Running prebuild script for $module"; \
+        /modules/$module/prebuild; \
+      fi; \
+        /pkg-oss/build_module.sh -v $NGINX_VERSION -f -y -o /tmp/packages -n $module $(cat /modules/$module/source); \
+    elif make -C /pkg-oss/debian list | grep -P "^$module\s+\d" > /dev/null; then \
+      echo "Building $module from pkg-oss sources"; \
+      cd /pkg-oss/debian; \
+      make rules-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
+      mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
+      make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
+      find ../../ -maxdepth 1 -mindepth 1 -type f -name "*.deb" -exec mv -v {} /tmp/packages/ \;; \
+    else \
+      echo "Don't know how to build $module module, exiting"; \
+      exit 1; \
+    fi; \
+  done
+
+
+FROM nginx:mainline as production-stage
+# For NGINX Modules
+ARG ENABLE_MODULES
+COPY --from=builder /tmp/packages /tmp/packages
+
 RUN mkdir /app
 COPY --from=build-stage /app/dist /app
 COPY nginx.conf /etc/nginx/nginx.template.conf
@@ -15,8 +78,11 @@ COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY cert/ /etc/nginx/cert
 
 RUN \
-  apt-get update --no-install-recommends && \
-  apt-get install openssl --no-install-recommends -y && \
-  rm /var/lib/apt/lists/* || true
+  apt update --no-install-recommends && \
+  apt install openssl --no-install-recommends -y && \
+  apt install --no-install-suggests --no-install-recommends -y \
+  /tmp/packages/nginx-module-brotli_${NGINX_VERSION}*.deb && \
+  rm -rf /tmp/packages && \
+  rm -rf /var/lib/apt/lists/
 
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -56,7 +56,7 @@ RUN set -ex \
       echo "Building $module from pkg-oss sources"; \
       cd /pkg-oss/debian; \
       make rules-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-      mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
+      mk-build-deps --install --tool="apt-get-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
       make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
       find ../../ -maxdepth 1 -mindepth 1 -type f -name "*.deb" -exec mv -v {} /tmp/packages/ \;; \
     else \

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -21,8 +21,8 @@ RUN set -ex \
 COPY ./ /modules/
 
 RUN set -ex \
-  && apt update \
-  && apt install -y --no-install-suggests --no-install-recommends \
+  && apt-get update \
+  && apt-get install -y --no-install-suggests --no-install-recommends \
   patch make wget mercurial devscripts debhelper dpkg-dev \
   quilt lsb-release build-essential libxml2-utils xsltproc \
   equivs git g++ \
@@ -41,7 +41,7 @@ RUN set -ex \
       # some modules require build dependencies
       if [ -f /modules/$module/build-deps ]; then \
         echo "Installing $module build dependencies"; \
-        apt update && apt install -y --no-install-suggests --no-install-recommends $(cat /modules/$module/build-deps | xargs); \
+        apt-get update && apt-get install -y --no-install-suggests --no-install-recommends $(cat /modules/$module/build-deps | xargs); \
       fi; \
       # if a module has a build dependency that is not in a distro, provide a
       # shell script to fetch/build/install those
@@ -56,7 +56,7 @@ RUN set -ex \
       echo "Building $module from pkg-oss sources"; \
       cd /pkg-oss/debian; \
       make rules-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-      mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
+      mk-build-deps --install --tool="apt-get-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
       make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
       find ../../ -maxdepth 1 -mindepth 1 -type f -name "*.deb" -exec mv -v {} /tmp/packages/ \;; \
     else \
@@ -78,11 +78,11 @@ COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY cert/ /etc/nginx/cert
 
 RUN \
-  apt update --no-install-recommends && \
-  apt install openssl --no-install-recommends -y && \
-  apt install --no-install-suggests --no-install-recommends -y \
+  apt-get update --no-install-recommends && \
+  apt-get install openssl --no-install-recommends -y && \
+  apt-get install --no-install-suggests --no-install-recommends -y \
   /tmp/packages/nginx-module-brotli_${NGINX_VERSION}*.deb && \
   rm -rf /tmp/packages && \
-  rm -rf /var/lib/apt/lists/
+  rm -rf /var/lib/apt-get/lists/
 
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -56,7 +56,7 @@ RUN set -ex \
       echo "Building $module from pkg-oss sources"; \
       cd /pkg-oss/debian; \
       make rules-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-      mk-build-deps --install --tool="apt-get-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
+      mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
       make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
       find ../../ -maxdepth 1 -mindepth 1 -type f -name "*.deb" -exec mv -v {} /tmp/packages/ \;; \
     else \

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -7,70 +7,7 @@ COPY ./ .
 FROM develop-stage as build-stage
 RUN npm run build
 
-
-FROM nginx:mainline as builder
-
-ARG ENABLED_MODULES
-
-RUN set -ex \
-  && if [ "$ENABLED_MODULES" = "" ]; then \
-  echo "No additional modules enabled, exiting"; \
-  exit 1; \
-  fi
-
-COPY ./ /modules/
-
-RUN set -ex \
-  && apt-get update \
-  && apt-get install -y --no-install-suggests --no-install-recommends \
-  patch make wget mercurial devscripts debhelper dpkg-dev \
-  quilt lsb-release build-essential libxml2-utils xsltproc \
-  equivs git g++ \
-  && hg clone https://hg.nginx.org/pkg-oss/ \
-  && cd pkg-oss \
-  && mkdir /tmp/packages \
-  && for module in $ENABLED_MODULES; do \
-    echo "Building $module for nginx-$NGINX_VERSION"; \
-    if [ -d /modules/$module ]; then \
-      echo "Building $module from user-supplied sources"; \
-      # check if module sources file is there and not empty
-      if [ ! -s /modules/$module/source ]; then \
-        echo "No source file for $module in modules/$module/source, exiting"; \
-        exit 1; \
-      fi; \
-      # some modules require build dependencies
-      if [ -f /modules/$module/build-deps ]; then \
-        echo "Installing $module build dependencies"; \
-        apt-get update && apt-get install -y --no-install-suggests --no-install-recommends $(cat /modules/$module/build-deps | xargs); \
-      fi; \
-      # if a module has a build dependency that is not in a distro, provide a
-      # shell script to fetch/build/install those
-      # note that shared libraries produced as a result of this script will
-      # not be copied from the builder image to the main one so build static
-      if [ -x /modules/$module/prebuild ]; then \
-        echo "Running prebuild script for $module"; \
-        /modules/$module/prebuild; \
-      fi; \
-        /pkg-oss/build_module.sh -v $NGINX_VERSION -f -y -o /tmp/packages -n $module $(cat /modules/$module/source); \
-    elif make -C /pkg-oss/debian list | grep -P "^$module\s+\d" > /dev/null; then \
-      echo "Building $module from pkg-oss sources"; \
-      cd /pkg-oss/debian; \
-      make rules-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-      mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" debuild-module-$module/nginx-$NGINX_VERSION/debian/control; \
-      make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-      find ../../ -maxdepth 1 -mindepth 1 -type f -name "*.deb" -exec mv -v {} /tmp/packages/ \;; \
-    else \
-      echo "Don't know how to build $module module, exiting"; \
-      exit 1; \
-    fi; \
-  done
-
-
-FROM nginx:mainline as production-stage
-# For NGINX Modules
-ARG ENABLE_MODULES
-COPY --from=builder /tmp/packages /tmp/packages
-
+FROM nginx as production-stage
 RUN mkdir /app
 COPY --from=build-stage /app/dist /app
 COPY nginx.conf /etc/nginx/nginx.template.conf
@@ -80,9 +17,6 @@ COPY cert/ /etc/nginx/cert
 RUN \
   apt-get update --no-install-recommends && \
   apt-get install openssl --no-install-recommends -y && \
-  apt-get install --no-install-suggests --no-install-recommends -y \
-  /tmp/packages/nginx-module-brotli_${NGINX_VERSION}*.deb && \
-  rm -rf /tmp/packages && \
-  rm -rf /var/lib/apt-get/lists/
+  rm /var/lib/apt/lists/* || true
 
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -20,6 +20,7 @@ http {
   map $sent_http_content_type $expires {
       text/css                   30d;
       application/javascript     30d;
+      application/json            5m;
   }
 
   proxy_cache_path /tmp/micro_cache levels=1:2 keys_zone=micro_cache:100m max_size=100m inactive=300s;
@@ -68,12 +69,14 @@ http {
     if ($request_method !~ ^(DELETE|GET|POST)$ ){
       return 405;
     }
-    # prevent clickjack attacks
-    add_header X-Frame-Options "SAMEORIGIN";
-    # prevent XSS attacks
-    add_header X-XSS-Protection "1; mode=block";
-    # Configuring HSTS
-    add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;
+    
+    # Headers
+    add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks
+    add_header X-XSS-Protection "1; mode=block";                                                  # prevent XSS attacks
+    add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;   # Configuring HSTS
+    add_header CC-X-Request-ID $request_id;
+    add_header X-Cache_Status $upstream_cache_status;
+
     # Secure Diffie-Hellman for TLS
     ssl_dhparam /etc/nginx/cert/${HOST}.pem;
 
@@ -81,18 +84,13 @@ http {
     ssl_session_timeout 10m;
     
     # Enable session tickets
-    ssl_session_tickets off;
+    ssl_session_tickets on;
 
     # OCSP stapling
     ssl_stapling on;
     ssl_stapling_verify on;
     resolver 8.8.8.8 8.8.4.4 208.67.222.222 208.67.220.220 valid=60s;
     resolver_timeout 2s;
-
-    # More Headers
-    add_header CC-X-Request-ID $request_id;
-    add_header X-Cache_Status $upstream_cache_status;
-
 
     # simple secure admin panel, will change later
     location ~* ^/admin {

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -70,7 +70,7 @@ http {
       return 405;
     }
     
-    # Headers asdf
+    # Headers
     add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks
     add_header X-XSS-Protection "1; mode=block";                                                  # prevent XSS attacks
     add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;   # Configuring HSTS

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -36,7 +36,7 @@ http {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_tokens off;
-    # expires $expires;
+    expires $expires;
 
     # ----- GZIP -----
     gzip on;

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -3,9 +3,6 @@ worker_processes  1;
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
-load_module modules/ngx_http_brotli_filter_module.so;
-load_module modules/ngx_http_brotli_static_module.so;
-
 events {
   worker_connections  1024;
 }

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -17,7 +17,7 @@ http {
   map $sent_http_content_type $expires {
       text/css                   30d;
       application/javascript     30d;
-      application/json            5m;
+      application/json           60m;
   }
 
   proxy_cache_path /tmp/micro_cache levels=1:2 keys_zone=micro_cache:100m max_size=100m inactive=3600s;
@@ -59,11 +59,6 @@ http {
     if ($request_method !~ ^(DELETE|GET|POST)$ ){
       return 405;
     }
-
-    # If user agent is a program/bot, block
-    if ($http_user_agent ~* "java|curl|python") {
-      return 403;
-    }
     
     # Headers
     add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks
@@ -84,7 +79,7 @@ http {
     # OCSP stapling
     ssl_stapling on;
     ssl_stapling_verify on;
-    resolver 8.8.8.8 8.8.4.4 208.67.222.222 208.67.220.220 valid=60s;
+    resolver 8.8.8.8 8.8.4.4 208.67.222.222 208.67.220.220 valid=60s;       # Google and Cisco
     resolver_timeout 2s;
 
     # simple secure admin panel, will change later
@@ -97,7 +92,6 @@ http {
     # serve Flask
     location / {
       root /app;
-      proxy_set_header Connection "";
       index index.html;
       try_files $uri $uri/ /index.html;
     }

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -63,7 +63,7 @@ http {
       return 405;
     }
     
-    # Headers asdf
+    # Headers
     add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks
     add_header X-XSS-Protection "1; mode=block";                                                  # prevent XSS attacks
     add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;   # Configuring HSTS

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -70,7 +70,7 @@ http {
       return 405;
     }
     
-    # Headers
+    # Headers asdf
     add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks
     add_header X-XSS-Protection "1; mode=block";                                                  # prevent XSS attacks
     add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;   # Configuring HSTS

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -3,6 +3,9 @@ worker_processes  1;
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
+load_module modules/ngx_http_brotli_filter_module.so;
+load_module modules/ngx_http_brotli_static_module.so;
+
 events {
   worker_connections  1024;
 }
@@ -13,16 +16,15 @@ http {
   default_type application/octet-stream;
   keepalive_timeout  65;
 
-# Expires map
-  map $sent_http_content_type $expires {
-      default                    off;
-      text/html                  epoch;
-      text/css                   max;
-      application/javascript     max;
-      ~image/                    max;
-  }
+  # Expires map
+  # map $sent_http_content_type $expires {
+  #     text/css                   30d;
+  #     application/javascript     30d;
+  #     application/json            5m;
+  #     ~image/                    30d;
+  # }
 
-
+  proxy_cache_path /tmp/micro_cache levels=1:2 keys_zone=micro_cache:100m max_size=100m inactive=600s;
 
   server{
     listen 80;
@@ -35,16 +37,26 @@ http {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_tokens off;
-    expires $expires;
+    # expires $expires;
 
     # ----- GZIP -----
-    gzip on;
-    gzip_static on;    
-    gzip_proxied  any;
-    gzip_vary on;
-    gzip_comp_level 6;
-    gzip_buffers 16 8k; 
+    # gzip on;
+    # gzip_static on;    
+    # gzip_proxied  any;
+    # gzip_vary on;
+    # gzip_comp_level 6;
+    # gzip_buffers 16 8k;
+    # gzip_min_length 600;
+    # gzip_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
     
+    # Brotli Settings
+    # brotli on;
+    # brotli_comp_level 4;
+    # brotli_buffers 32 8k;
+    # brotli_min_length 100;
+    # brotli_static on;
+    # brotli_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
+
     ssl_certificate      /etc/nginx/cert/${HOST}.crt;
     ssl_certificate_key  /etc/nginx/cert/${HOST}.key;
 
@@ -63,21 +75,25 @@ http {
     # prevent XSS attacks
     add_header X-XSS-Protection "1; mode=block";
     # Configuring HSTS
-    add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
+    add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;
     # Secure Diffie-Hellman for TLS
     ssl_dhparam /etc/nginx/cert/${HOST}.pem;
 
     ssl_session_cache shared:TLS:10m;
     ssl_session_timeout 10m;
-    ssl_buffer_size 4k;
-
-    # Set HSTS to 365 days
-    add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;
+    
+    # Enable session tickets
+    ssl_session_tickets off;
 
     # OCSP stapling
     ssl_stapling on;
     ssl_stapling_verify on;
-    resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001]; # Cloudflare
+    resolver 8.8.8.8 8.8.4.4 208.67.222.222 208.67.220.220 valid=60s;
+    resolver_timeout 2s;
+
+    # More Headers
+    add_header CC-X-Request-ID $request_id;
+    add_header X-Cache_Status $upstream_cache_status;
 
 
     # simple secure admin panel, will change later
@@ -90,12 +106,23 @@ http {
     # serve Flask
     location / {
       root /app;
+      proxy_set_header Connection "";
       index index.html;
       try_files $uri $uri/ /index.html;
     }
 
     # Serve API routes
     location /api {
+      # Micro Cache
+      proxy_cache micro_cache;
+      proxy_cache_valid 200 1s;
+      proxy_cache_use_stale updating;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+
+      proxy_cache_revalidate on;
+      proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+      
       proxy_pass http://yacs_api:5000;
       client_max_body_size 3M;
     }

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -17,14 +17,12 @@ http {
   keepalive_timeout  65;
 
   # Expires map
-  # map $sent_http_content_type $expires {
-  #     text/css                   30d;
-  #     application/javascript     30d;
-  #     application/json            5m;
-  #     ~image/                    30d;
-  # }
+  map $sent_http_content_type $expires {
+      text/css                   30d;
+      application/javascript     30d;
+  }
 
-  proxy_cache_path /tmp/micro_cache levels=1:2 keys_zone=micro_cache:100m max_size=100m inactive=600s;
+  proxy_cache_path /tmp/micro_cache levels=1:2 keys_zone=micro_cache:100m max_size=100m inactive=300s;
 
   server{
     listen 80;
@@ -37,7 +35,7 @@ http {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_tokens off;
-    # expires $expires;
+    expires $expires;
 
     # ----- GZIP -----
     # gzip on;
@@ -49,13 +47,13 @@ http {
     # gzip_min_length 600;
     # gzip_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
     
-    # Brotli Settings
-    # brotli on;
-    # brotli_comp_level 4;
-    # brotli_buffers 32 8k;
-    # brotli_min_length 100;
-    # brotli_static on;
-    # brotli_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
+    # Brotli
+    brotli on;
+    brotli_comp_level 4;
+    brotli_buffers 32 8k;
+    brotli_min_length 100;
+    brotli_static on;
+    brotli_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
 
     ssl_certificate      /etc/nginx/cert/${HOST}.crt;
     ssl_certificate_key  /etc/nginx/cert/${HOST}.key;

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -62,11 +62,6 @@ http {
     if ($request_method !~ ^(DELETE|GET|POST)$ ){
       return 405;
     }
-
-    # If user agent is a program/bot, block
-    if ($http_user_agent ~* "java|curl|python") {
-      return 403;
-    }
     
     # Headers
     add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -63,7 +63,7 @@ http {
       return 405;
     }
     
-    # Headers
+    # Headers asdf
     add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks
     add_header X-XSS-Protection "1; mode=block";                                                  # prevent XSS attacks
     add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;   # Configuring HSTS

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -62,6 +62,11 @@ http {
     if ($request_method !~ ^(DELETE|GET|POST)$ ){
       return 405;
     }
+
+    # If user agent is a program/bot, block
+    if ($http_user_agent ~* "java|curl|python") {
+      return 403;
+    }
     
     # Headers
     add_header X-Frame-Options "SAMEORIGIN";                                                      # prevent clickjack attacks

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -23,7 +23,7 @@ http {
       application/json            5m;
   }
 
-  proxy_cache_path /tmp/micro_cache levels=1:2 keys_zone=micro_cache:100m max_size=100m inactive=300s;
+  proxy_cache_path /tmp/micro_cache levels=1:2 keys_zone=micro_cache:100m max_size=100m inactive=3600s;
 
   server{
     listen 80;

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -36,7 +36,7 @@ http {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_tokens off;
-    expires $expires;
+    # expires $expires;
 
     # ----- GZIP -----
     gzip on;

--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -39,22 +39,14 @@ http {
     expires $expires;
 
     # ----- GZIP -----
-    # gzip on;
-    # gzip_static on;    
-    # gzip_proxied  any;
-    # gzip_vary on;
-    # gzip_comp_level 6;
-    # gzip_buffers 16 8k;
-    # gzip_min_length 600;
-    # gzip_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
-    
-    # Brotli
-    brotli on;
-    brotli_comp_level 4;
-    brotli_buffers 32 8k;
-    brotli_min_length 100;
-    brotli_static on;
-    brotli_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
+    gzip on;
+    gzip_static on;    
+    gzip_proxied  any;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_min_length 600;
+    gzip_types image/jpeg image/bmp image/svg+xml text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon;
 
     ssl_certificate      /etc/nginx/cert/${HOST}.crt;
     ssl_certificate_key  /etc/nginx/cert/${HOST}.key;
@@ -65,9 +57,15 @@ http {
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers   on;
     ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA HIGH !RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
-    # disabling unwanted http methods
+    
+    # Disabling unwanted http methods
     if ($request_method !~ ^(DELETE|GET|POST)$ ){
       return 405;
+    }
+
+    # If user agent is a program/bot, block
+    if ($http_user_agent ~* "java|curl|python") {
+      return 403;
     }
     
     # Headers

--- a/src/web/src/routes.js
+++ b/src/web/src/routes.js
@@ -1,14 +1,13 @@
 import VueRouter from "vue-router";
-import AdminPage from "./pages/Admin";
-import StudentPage from "./pages/Student";
-import CourseSchedulerPage from "./pages/CourseScheduler";
-import UploadCsvPage from "./pages/UploadCsv";
-import EditSemestersPage from "./pages/EditSemesters";
-import CourseExplorerPage from "./pages/CourseExplorer";
-import CoursePage from "./pages/CoursePage";
-import DegreeTemplatesPage from "./pages/DegreeTemplates";
-import SubjectExplorerPage from "./pages/SubjectExplorer";
-import NotFoundPage from "./pages/NotFound";
+const AdminPage = () => import("./pages/Admin");
+const StudentPage = () => import("./pages/Student");
+const CourseSchedulerPage = () => import("./pages/CourseScheduler");
+const UploadCsvPage = () => import("./pages/UploadCsv");
+const EditSemestersPage = () => import("./pages/EditSemesters");
+const CourseExplorerPage = () => import("./pages/CourseExplorer");
+const CoursePage = () => import("./pages/CoursePage");
+const DegreeTemplatesPage = () => import("./pages/DegreeTemplates");
+const SubjectExplorerPage = () => import("./pages/SubjectExplorer");
 
 var router = new VueRouter({
   routes: [

--- a/src/web/src/routes.js
+++ b/src/web/src/routes.js
@@ -8,6 +8,7 @@ const CourseExplorerPage = () => import("./pages/CourseExplorer");
 const CoursePage = () => import("./pages/CoursePage");
 const DegreeTemplatesPage = () => import("./pages/DegreeTemplates");
 const SubjectExplorerPage = () => import("./pages/SubjectExplorer");
+const NotFoundPage = () => import("./pages/NotFound");
 
 var router = new VueRouter({
   routes: [


### PR DESCRIPTION
_This is a new PR to the old [PR](https://github.com/YACS-RCOS/yacs.n/pull/422). It just stopped looking at updated pushes that I made. IDK why it stopped, nor do I want to put the time to figure that out_

Issue
A possible fix to issue #418 

Sometimes, when updating semester courses, it would still display the old course because it's not actually pinging origin server; it's taking it from the nginx proxy server. Hopefully, shorting the cache age would help. Also took out gzip and implemented Brotli.

Additional Info

If Brotli is not desired, Gzip can be used.