### PR TITLE
Moving to vuex

### DIFF
--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -5,44 +5,17 @@
 </template>
 
 <script>
-import { TOGGLE_DARK_MODE, SET_COURSE_LIST } from "@/store";
-import { getCourses } from "@/services/YacsService";
-import { getDefaultSemester } from "@/services/AdminService";
+import { LOAD_DEPARTMENTS, TOGGLE_DARK_MODE } from "@/store";
 
 export default {
   name: "App",
   components: {},
   async created() {
-    const querySemester = this.$route.query.semester;
-    this.selectedSemester =
-      querySemester && querySemester != "null"
-        ? querySemester
-        : await getDefaultSemester();
-    const courses = await getCourses(this.selectedSemester);
-    this.$store.commit(SET_COURSE_LIST, courses);
-
     if (this.$cookies.get("darkMode") == "true") {
-      this.$store.commit(TOGGLE_DARK_MODE);
+      this.$store.commit(TOGGLE_DARK_MODE, true);
     }
-  },
-  computed: {
-    darkMode() {
-      return this.$store.state.darkMode;
-    },
-  },
-  watch: {
-    darkMode(newState, oldState) {
-      if (newState === oldState) {
-        return;
-      }
 
-      const bodyClassList = document.getElementsByTagName("body")[0].classList;
-      if (newState) {
-        bodyClassList.add("dark");
-      } else {
-        bodyClassList.remove("dark");
-      }
-    },
+    this.$store.dispatch(LOAD_DEPARTMENTS);
   },
   metaInfo() {
     return {

--- a/src/web/src/components/CourseList.vue
+++ b/src/web/src/components/CourseList.vue
@@ -90,7 +90,7 @@
 
 <script>
 import "@/typedef";
-
+import { mapState } from "vuex";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 
 import { DAY_SHORTNAMES } from "@/utils";
@@ -108,11 +108,6 @@ export default {
     DynamicScroller,
     DynamicScrollerItem,
   },
-  props: {
-    courses: Array,
-    subsemesters: Array,
-    selectedSemester: null,
-  },
   data() {
     return {
       faInfoCircle,
@@ -120,8 +115,9 @@ export default {
       textSearch: "",
       selectedSubsemester: null,
       selectedDepartment: null,
-      departmentOptions: [{ text: "All", value: null }],
-      courseList: this.courses,
+      // departmentOptions: [{ text: "All", value: null }],
+      // courseList: this.courses,
+      courseList: null,
       debounceTime: 300,
     };
   },
@@ -150,6 +146,14 @@ export default {
     },
   },
   computed: {
+    ...mapState(["selectedSemester", "subsemesters", "departments"]),
+
+    departmentOptions() {
+      return [{ text: "All", value: null }].concat(
+        ...this.departments.map(({ department }) => department)
+      );
+    },
+
     subsemesterOptions() {
       let options = [{ text: "All", value: null }];
       options.push(
@@ -166,8 +170,13 @@ export default {
     // returns exact match if possible.
     // if no exact match exists, returns similar options.
     filterCourses() {
+      const courses =
+        this.courseList !== null
+          ? this.courseList
+          : this.$store.getters.courses;
+
       // filter by selected department
-      const filtered = this.courseList.filter(
+      const filtered = courses.filter(
         (course) =>
           (!this.selectedDepartment ||
             course.department === this.selectedDepartment) &&
@@ -189,12 +198,6 @@ export default {
 
       if (find) return [find];
       else return filtered;
-    },
-    // return a list of the titles of each course.
-    mapCourseNames() {
-      return this.filterCourses.map((course) => {
-        return course.full_title || course.title;
-      });
     },
   },
 };

--- a/src/web/src/components/DepartmentList.vue
+++ b/src/web/src/components/DepartmentList.vue
@@ -38,7 +38,6 @@ export default {
   props: {
     majors: Set,
     deptClassDict: Object,
-    selectedSemester: String,
     id: Number,
   },
 

--- a/src/web/src/components/Footer.vue
+++ b/src/web/src/components/Footer.vue
@@ -10,7 +10,7 @@
               :key="option.text"
               class="link"
               :disabled="option.text === selectedSemester"
-              @click="updateSelectedSemester(option.text)"
+              @click="selectSemester(option.value)"
             >
               {{ option.value }}
             </a>
@@ -75,37 +75,27 @@
 </template>
 
 <script>
-import { getSemesters } from "@/services/YacsService";
+import { SELECT_SEMESTER } from "@/store";
+import { mapState, mapActions } from "vuex";
 
 export default {
   name: "Footer",
-  props: {
-    selectedSemester: String,
-  },
-  data() {
-    return {
-      semesterOptions: [],
-    };
-  },
-  methods: {
-    updateSelectedSemester(newSemester) {
-      this.$emit("changeSelectedSemester", newSemester);
-    },
-  },
   computed: {
+    ...mapState(["semesters", "selectedSemester"]),
     otherSemesters() {
       return this.semesterOptions.filter(
-        (semester) => semester.text != this.semester
+        (semester) => semester.value !== this.selectedSemester
       );
     },
-  },
-  created() {
-    getSemesters().then((data) => {
-      this.semesterOptions = data.map((s) => ({
-        text: s.semester,
-        value: s.semester,
+    semesterOptions() {
+      return this.semesters.map(({ semester }) => ({
+        text: semester,
+        value: semester,
       }));
-    });
+    },
+  },
+  methods: {
+    ...mapActions([SELECT_SEMESTER]),
   },
 };
 </script>

--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -103,18 +103,11 @@ import { userTypes } from "../store/modules/user";
 
 export default {
   name: "Header",
-  props: {
-    selectedSemester: String,
-  },
   components: {
     SignUpForm: SignUpComponent,
     LoginForm: LoginComponent,
   },
-  data() {
-    return {
-      semesterOptions: [],
-    };
-  },
+
   methods: {
     toggle_style() {
       this.$store.commit(TOGGLE_DARK_MODE);
@@ -145,6 +138,7 @@ export default {
       isLoggedIn: userTypes.getters.IS_LOGGED_IN,
       user: userTypes.getters.CURRENT_USER_INFO,
     }),
+    ...mapState(["selectedSemester"]),
     ...mapState({ sessionId: userTypes.state.SESSION_ID }),
   },
 };

--- a/src/web/src/components/Schedule.vue
+++ b/src/web/src/components/Schedule.vue
@@ -75,7 +75,9 @@ export default {
     ScheduleEvent: ScheduleEventComponent,
   },
   props: {
-    schedule: Schedule,
+    schedule: {
+      default: () => new Schedule(),
+    },
   },
   data() {
     return {

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid>
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
-    <div v-if="courses.length != 0" class="mx-auto w-75">
+    <div v-if="!isLoadingCourses && courses.length > 0" class="mx-auto w-75">
       <b-row>
         <!--
         - Left side of the column
@@ -67,7 +67,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 import { COURSES } from "@/store";
 import DepartmentListComponenet from "@/components/DepartmentList";
 import { generateRequirementsText } from "@/utils";
@@ -96,6 +96,7 @@ export default {
     generateRequirementsText,
   },
   computed: {
+    ...mapState(["isLoadingCourses"]),
     ...mapGetters([COURSES]),
     schoolDepartmentObjects() {
       let keyArr = Object.entries(this.schoolsMajorDict)

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid>
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
-    <div v-if="$store.state.courseList.length != 0" class="mx-auto w-75">
+    <div v-if="courses.length != 0" class="mx-auto w-75">
       <b-row>
         <!--
         - Left side of the column
@@ -24,7 +24,6 @@
                 <DepartmentList
                   :majors="deptObj.departments"
                   :deptClassDict="deptClassDict"
-                  :selectedSemester="selectedSemester"
                   v-on:showCourseInfo="showCourseInfo($event)"
                 ></DepartmentList>
               </b-row>
@@ -49,7 +48,6 @@
                 <DepartmentList
                   :majors="deptObj.departments"
                   :deptClassDict="deptClassDict"
-                  :selectedSemester="selectedSemester"
                   v-on:showCourseInfo="showCourseInfo($event)"
                 ></DepartmentList>
               </b-row>
@@ -69,6 +67,8 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
+import { COURSES } from "@/store";
 import DepartmentListComponenet from "@/components/DepartmentList";
 import { generateRequirementsText } from "@/utils";
 import CenterSpinnerComponent from "../components/CenterSpinner";
@@ -78,9 +78,6 @@ export default {
   components: {
     DepartmentList: DepartmentListComponenet,
     CenterSpinner: CenterSpinnerComponent,
-  },
-  props: {
-    selectedSemester: String,
   },
   data() {
     return {
@@ -99,6 +96,7 @@ export default {
     generateRequirementsText,
   },
   computed: {
+    ...mapGetters([COURSES]),
     schoolDepartmentObjects() {
       let keyArr = Object.entries(this.schoolsMajorDict)
         .map((schoolDepartmentMapping) => ({
@@ -119,7 +117,7 @@ export default {
     },
     schoolsMajorDict() {
       let schoolsMajorDict = {};
-      for (const c of this.$store.state.courseList) {
+      for (const c of this.courses) {
         if (!schoolsMajorDict[c.school]) {
           schoolsMajorDict[c.school] = new Set();
         }
@@ -129,7 +127,7 @@ export default {
     },
     deptClassDict() {
       let deptClassDict = {};
-      for (const c of this.$store.state.courseList) {
+      for (const c of this.courses) {
         if (deptClassDict[c.department]) {
           deptClassDict[c.department].push(c);
         } else {

--- a/src/web/src/pages/CoursePage.vue
+++ b/src/web/src/pages/CoursePage.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid>
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
-    <div v-if="courses.length != 0" class="w-90 ml-4 mb-4">
+    <div v-if="!isLoadingCourses && courses.length > 0" class="w-90 ml-4 mb-4">
       <b-row>
         <b-col>
           <h1 class="mt-4">{{ courseObj.title }}</h1>
@@ -41,7 +41,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 import { COURSES } from "@/store";
 import { generateRequirementsText } from "@/utils";
 import CenterSpinnerComponent from "../components/CenterSpinner.vue";
@@ -79,6 +79,7 @@ export default {
     generateRequirementsText,
   },
   computed: {
+    ...mapState(["isLoadingCourses"]),
     ...mapGetters([COURSES]),
     transformed() {
       let precoreqtext = this.courseObj.raw_precoreqs;

--- a/src/web/src/pages/CoursePage.vue
+++ b/src/web/src/pages/CoursePage.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid>
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
-    <div v-if="!isLoadingCourses && courses.length > 0" class="w-90 ml-4 mb-4">
+    <div v-if="!isLoadingCourses && courseObj" class="w-90 ml-4 mb-4">
       <b-row>
         <b-col>
           <h1 class="mt-4">{{ courseObj.title }}</h1>
@@ -31,12 +31,20 @@
       <b-button :to="'/explore/' + courseObj.department">Back</b-button>
     </div>
     <CenterSpinner
-      v-else
+      v-else-if="isLoadingCourses"
       :height="80"
       :fontSize="1.4"
       loadingMessage="Course"
       :topSpacing="30"
     />
+    <!-- If !courseObj -->
+    <div v-else class="w-90 ml-4 mb-4">
+      <b-row>
+        <b-col>
+          <h1 class="mt-4">Course not found</h1>
+        </b-col>
+      </b-row>
+    </div>
   </b-container>
 </template>
 

--- a/src/web/src/pages/CoursePage.vue
+++ b/src/web/src/pages/CoursePage.vue
@@ -135,7 +135,7 @@ export default {
     return {
       title: this.courseTitle,
       titleTemplate: "%s | YACS",
-      meta: [
+      meta: !this.courseObj ? undefined : [
         {
           vmid: "description",
           name: "description",

--- a/src/web/src/pages/CoursePage.vue
+++ b/src/web/src/pages/CoursePage.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid>
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
-    <div v-if="$store.state.courseList.length != 0" class="w-90 ml-4 mb-4">
+    <div v-if="courses.length != 0" class="w-90 ml-4 mb-4">
       <b-row>
         <b-col>
           <h1 class="mt-4">{{ courseObj.title }}</h1>
@@ -41,6 +41,8 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
+import { COURSES } from "@/store";
 import { generateRequirementsText } from "@/utils";
 import CenterSpinnerComponent from "../components/CenterSpinner.vue";
 import CourseSectionsOpenBadge from "../components/CourseSectionsOpenBadge.vue";
@@ -77,6 +79,7 @@ export default {
     generateRequirementsText,
   },
   computed: {
+    ...mapGetters([COURSES]),
     transformed() {
       let precoreqtext = this.courseObj.raw_precoreqs;
       if (precoreqtext === null) {
@@ -105,9 +108,7 @@ export default {
       return precoreqtext;
     },
     courseObj() {
-      return this.$store.state.courseList.find(
-        (course) => course.name === this.courseName
-      );
+      return this.courses.find((course) => course.name === this.courseName);
     },
     getCredits() {
       var credits;

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -25,10 +25,7 @@
                   @addCourse="addCourse"
                   @removeCourse="removeCourse"
                   @showCourseInfo="showCourseInfo"
-                  :courses="courses"
-                  :subsemesters="subsemesters"
                   class="w-100"
-                  :selectedSemester="selectedSemester"
                 />
               </b-card-text>
             </b-tab>
@@ -164,7 +161,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 
 import NotificationsMixin from "@/mixins/NotificationsMixin";
 import ScheduleComponent from "@/components/Schedule";
@@ -179,11 +176,11 @@ import { SelectedCoursesCookie } from "../controllers/SelectedCoursesCookie";
 
 import { userTypes } from "../store/modules/user";
 
-import { SET_COURSE_LIST } from "@/store";
+import { COURSES } from "@/store";
 
 import {
-  getSubSemesters,
-  getCourses,
+  // getSubSemesters,
+  // getCourses,
   addStudentCourse,
   removeStudentCourse,
   getStudentCourses,
@@ -208,16 +205,11 @@ export default {
     CourseList: CourseListComponent,
     CenterSpinner: CenterSpinnerComponent,
   },
-  props: {
-    selectedSemester: String,
-  },
   data() {
     return {
       selectedCourses: {},
       selectedScheduleSubsemester: null,
       scheduler: new Schedule(),
-      subsemesters: [],
-      courses: [],
       loading: false,
       exportIcon: faPaperPlane,
 
@@ -331,17 +323,6 @@ export default {
           selectedCoursesCookie.clear().save();
         }
       }
-    },
-    updateDataOnNewSemester(semester) {
-      return Promise.all([getCourses(semester), getSubSemesters(semester)])
-        .then(([courses, subsemesters]) => {
-          this.courses = courses;
-          this.subsemesters = subsemesters;
-          this.$store.commit(SET_COURSE_LIST, courses);
-        })
-        .then(() => {
-          this.loadStudentCourses(semester);
-        });
     },
     addCourse(course) {
       let i = 0;
@@ -477,6 +458,8 @@ export default {
     },
   },
   computed: {
+    ...mapState(["subsemesters", "selectedSemester"]),
+    ...mapGetters([COURSES]),
     ...mapGetters({ isLoggedIn: userTypes.getters.IS_LOGGED_IN }),
 
     selectedScheduleIndex() {
@@ -513,17 +496,6 @@ export default {
     },
   },
   watch: {
-    selectedSemester: {
-      immediate: true,
-      handler(semester) {
-        this.loading = true;
-        //this.$router.push({ name: "CourseScheduler", query: { semester } });
-
-        this.updateDataOnNewSemester(semester).then(
-          () => (this.loading = false)
-        );
-      },
-    },
     isLoggedIn: {
       immediate: true,
       handler() {

--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -63,7 +63,8 @@
           value-field="display_string"
         ></b-form-select>
 
-        <template v-if="scheduler.schedules">
+        <Schedule v-if="loading" />
+        <template v-else-if="scheduler.schedules">
           <Schedule
             v-for="(schedule, index) in scheduler.schedules"
             :key="index"
@@ -179,8 +180,6 @@ import { userTypes } from "../store/modules/user";
 import { COURSES } from "@/store";
 
 import {
-  // getSubSemesters,
-  // getCourses,
   addStudentCourse,
   removeStudentCourse,
   getStudentCourses,
@@ -210,7 +209,6 @@ export default {
       selectedCourses: {},
       selectedScheduleSubsemester: null,
       scheduler: new Schedule(),
-      loading: false,
       exportIcon: faPaperPlane,
 
       courseInfoModalCourse: null,
@@ -233,8 +231,8 @@ export default {
         }
       );
     },
-    async loadStudentCourses(semester) {
-      if (!semester) {
+    async loadStudentCourses() {
+      if (!this.courses.length) {
         return;
       }
 
@@ -462,6 +460,10 @@ export default {
     ...mapGetters([COURSES]),
     ...mapGetters({ isLoggedIn: userTypes.getters.IS_LOGGED_IN }),
 
+    loading() {
+      return this.$store.state.isLoadingCourses;
+    },
+
     selectedScheduleIndex() {
       return this.scheduler.scheduleSubsemesters.findIndex(
         (s) => s.display_string === this.selectedScheduleSubsemester
@@ -496,14 +498,16 @@ export default {
     },
   },
   watch: {
+    courses: {
+      immediate: true,
+      handler() {
+        this.loadStudentCourses();
+      },
+    },
     isLoggedIn: {
       immediate: true,
       handler() {
-        this.loading = true;
-
-        this.loadStudentCourses(this.selectedSemester).then(
-          () => (this.loading = false)
-        );
+        this.loadStudentCourses();
       },
     },
   },

--- a/src/web/src/pages/Student.vue
+++ b/src/web/src/pages/Student.vue
@@ -1,20 +1,16 @@
 <template>
   <div>
-    <Header class="mb-3" :selectedSemester="selectedSemester"></Header>
-    <router-view :selected-semester="selectedSemester" />
-    <Footer
-      :selectedSemester="selectedSemester"
-      @changeSelectedSemester="updateSelectedSemester"
-    />
+    <Header class="mb-3"></Header>
+    <router-view />
+    <Footer />
   </div>
 </template>
 
 <script>
 import { mapGetters } from "vuex";
-
+import { SELECT_SEMESTER } from "@/store";
 import HeaderComponent from "@/components/Header";
 import FooterComponent from "@/components/Footer";
-import { getDefaultSemester } from "@/services/AdminService";
 import { userTypes } from "@/store/modules/user";
 
 export default {
@@ -23,30 +19,15 @@ export default {
     Header: HeaderComponent,
     Footer: FooterComponent,
   },
-  data() {
-    return {
-      selectedSemester: "",
-    };
-  },
   async created() {
-    const querySemester = this.$route.query.semester;
-
-    this.selectedSemester =
-      querySemester && querySemester != "null"
-        ? querySemester
-        : await getDefaultSemester();
-
     try {
       if (!this.isLoggedIn) {
         await this.$store.dispatch(userTypes.actions.LOAD_SESSION_COOKIE);
       }
       // eslint-disable-next-line no-empty
     } catch {}
-  },
-  methods: {
-    updateSelectedSemester(newSemester) {
-      this.selectedSemester = newSemester;
-    },
+
+    await this.$store.dispatch(SELECT_SEMESTER, this.$route.query.semester);
   },
   computed: {
     ...mapGetters({

--- a/src/web/src/pages/Student.vue
+++ b/src/web/src/pages/Student.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import store from "@/store";
 import { SELECT_SEMESTER } from "@/store";
 import HeaderComponent from "@/components/Header";
 import FooterComponent from "@/components/Footer";
@@ -19,20 +19,19 @@ export default {
     Header: HeaderComponent,
     Footer: FooterComponent,
   },
-  async created() {
+  async beforeRouteEnter(to, from, next) {
     try {
-      if (!this.isLoggedIn) {
-        await this.$store.dispatch(userTypes.actions.LOAD_SESSION_COOKIE);
+      if (!store.getters[userTypes.getters.IS_LOGGED_IN]) {
+        await store.dispatch(userTypes.actions.LOAD_SESSION_COOKIE);
       }
       // eslint-disable-next-line no-empty
     } catch {}
 
-    await this.$store.dispatch(SELECT_SEMESTER, this.$route.query.semester);
-  },
-  computed: {
-    ...mapGetters({
-      isLoggedIn: userTypes.getters.IS_LOGGED_IN,
-    }),
+    if (store.state.selectedSemester === null || to.query.semester) {
+      await store.dispatch(SELECT_SEMESTER, to.query.semester);
+    }
+
+    next();
   },
 };
 </script>

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -6,7 +6,7 @@
       <h3 class="subjectBox">{{ subject }}</h3>
     </b-row>
     <!-- left column of courses -->
-    <b-row v-if="$store.state.courseList.length != 0">
+    <b-row v-if="courses.length != 0">
       <b-col cols="6">
         <b-row
           v-for="course in courseColumns[0]"
@@ -79,6 +79,7 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
 import CenterSpinnerComponent from "../components/CenterSpinner";
 import CourseSectionsOpenBadge from "../components/CourseSectionsOpenBadge.vue";
 
@@ -87,9 +88,6 @@ export default {
   components: {
     CenterSpinner: CenterSpinnerComponent,
     CourseSectionsOpenBadge,
-  },
-  props: {
-    selectedSemester: String,
   },
   data() {
     return {
@@ -112,13 +110,16 @@ export default {
   },
   methods: {},
   computed: {
+    ...mapGetters(["courses"]),
     //courseColumns[0] corresponds to left column, [1] to right column
     courseColumns() {
       let leftColumn = [];
       let rightColumn = [];
-      const courses = this.$store.state.courseList;
+
       //Obtain All Courses Such That Department Matches The Subject Name.
-      const allTempData = courses.filter((c) => c.department === this.subject);
+      const allTempData = this.courses.filter(
+        (c) => c.department === this.subject
+      );
       for (let k = 0; k < allTempData.length; k++) {
         if (k % 2 == 0) leftColumn.push(allTempData[k]);
         else rightColumn.push(allTempData[k]);

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -6,7 +6,7 @@
       <h3 class="subjectBox">{{ subject }}</h3>
     </b-row>
     <!-- left column of courses -->
-    <b-row v-if="courses.length != 0">
+    <b-row v-if="!isLoadingCourses && courses.length > 0">
       <b-col cols="6">
         <b-row
           v-for="course in courseColumns[0]"
@@ -79,7 +79,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 import CenterSpinnerComponent from "../components/CenterSpinner";
 import CourseSectionsOpenBadge from "../components/CourseSectionsOpenBadge.vue";
 
@@ -110,6 +110,7 @@ export default {
   },
   methods: {},
   computed: {
+    ...mapState(["isLoadingCourses"]),
     ...mapGetters(["courses"]),
     //courseColumns[0] corresponds to left column, [1] to right column
     courseColumns() {

--- a/src/web/src/store/index.js
+++ b/src/web/src/store/index.js
@@ -1,21 +1,55 @@
 import Vue from "vue";
 import Vuex from "vuex";
+import axios from "axios";
+
+import { getDefaultSemester } from "@/services/AdminService";
+import { getCourses } from "@/services/YacsService";
+import { readableDate, localToUTCDate } from "@/utils";
 
 import { userModule, USER_NAMESPACE } from "./modules/user";
 
+const client = axios.create({
+  baseURL: "/api",
+});
+
 Vue.use(Vuex);
 
-export const TOGGLE_DARK_MODE = "TOGGLE_DARK_MODE";
-export const SET_COURSE_LIST = "SET_COURSE_LIST";
+// Constants are UPPER_SNAKE_CASE but we set the values to
+//  camelCase so when using mapMutations, mapActions, etc.
+//  they will map to camelCase names
+export const COURSES = "courses";
+export const GET_COURSE_BY_ID = "getCourseById";
+
+export const TOGGLE_DARK_MODE = "toggleDarkMode";
+export const SET_COURSES = "setCourses";
+export const SET_SELECTED_SEMESTER = "setSelectedSemester";
+export const SET_SEMESTERS = "setSemesters";
+export const SET_SUBSEMESTERS = "setSubsemesters";
+export const SET_DEPARTMENTS = "setDepartments";
+
+export const LOAD_COURSES = "loadCourses";
+export const SELECT_SEMESTER = "selectSemester";
+export const LOAD_SEMESTERS = "loadSemesters";
+export const LOAD_SUBSEMESTERS = "loadSubsemesters";
+export const LOAD_DEPARTMENTS = "loadDepartments";
 
 const store = new Vuex.Store({
   state: {
     darkMode: false,
-    courseList: [],
+    coursesById: {},
+    selectedSemester: null,
+    semesters: [],
+    subsemesters: [],
+    departments: [],
+  },
+  getters: {
+    [COURSES]: (state) => Object.values(state.coursesById),
+    [GET_COURSE_BY_ID]: (state) => (id) => state.coursesById[id],
   },
   mutations: {
-    [TOGGLE_DARK_MODE](state) {
-      state.darkMode = !state.darkMode;
+    [TOGGLE_DARK_MODE](state, isDarkMode = null) {
+      state.darkMode = isDarkMode === null ? !state.darkMode : isDarkMode;
+
       Vue.$cookies.set(
         "darkMode",
         state.darkMode,
@@ -25,9 +59,96 @@ const store = new Vuex.Store({
         null,
         "Strict"
       );
+      const bodyClassList = document.getElementsByTagName("body")[0].classList;
+      if (state.darkMode) {
+        bodyClassList.add("dark");
+      } else {
+        bodyClassList.remove("dark");
+      }
     },
-    [SET_COURSE_LIST](state, classes) {
-      state.courseList = classes;
+    [SET_COURSES](state, classes) {
+      state.coursesById = classes.reduce((coursesById, course) => {
+        coursesById[course.id] = course;
+        return coursesById;
+      }, {});
+    },
+    [SET_SELECTED_SEMESTER](state, semester) {
+      state.selectedSemester = semester;
+    },
+    [SET_SUBSEMESTERS](state, subsemesters) {
+      state.subsemesters = subsemesters;
+    },
+    [SET_DEPARTMENTS](state, departments) {
+      state.departments = departments;
+    },
+    [SET_SEMESTERS](state, semesters) {
+      state.semesters = semesters;
+    },
+  },
+  actions: {
+    async [LOAD_COURSES]({ state, commit }) {
+      const courses = await getCourses(state.selectedSemester);
+
+      commit(SET_COURSES, courses);
+    },
+    async [SELECT_SEMESTER]({ state, commit, dispatch }, semester) {
+      if (state.semesters.length === 0) {
+        await dispatch(LOAD_SEMESTERS);
+      }
+
+      if (!semester || !state.semesters.find((s) => s.semester === semester)) {
+        semester = await getDefaultSemester();
+      }
+
+      if (!semester || semester === state.selectedSemester) {
+        return;
+      }
+      commit(SET_SELECTED_SEMESTER, semester);
+
+      await Promise.all([dispatch(LOAD_COURSES), dispatch(LOAD_SUBSEMESTERS)]);
+    },
+    async [LOAD_SEMESTERS]({ commit }) {
+      const semesters = await client.get("/semester").then((res) => res.data);
+
+      commit(SET_SEMESTERS, semesters);
+    },
+    async [LOAD_SUBSEMESTERS]({ state, commit }) {
+      const subsemesters = await client
+        .get("/subsemester", {
+          params: {
+            semester: state.selectedSemester,
+          },
+        })
+        .then(({ data }) => {
+          return data.map((subsemester) => {
+            subsemester.date_start = localToUTCDate(
+              new Date(subsemester.date_start)
+            );
+            subsemester.date_end = localToUTCDate(
+              new Date(subsemester.date_end)
+            );
+            subsemester.date_start_display = readableDate(
+              subsemester.date_start
+            );
+            subsemester.date_end_display = readableDate(subsemester.date_end);
+            // Used to determine what semester the subsemester is part of
+            subsemester.semester_name = subsemester.parent_semester_name;
+            subsemester.display_string = subsemester.semester_part_name
+              ? subsemester.semester_part_name
+              : `${subsemester.date_start_display} - ${subsemester.date_end_display}`;
+
+            return subsemester;
+          });
+        });
+
+      commit(SET_SUBSEMESTERS, subsemesters);
+    },
+    async [LOAD_DEPARTMENTS]({ commit }) {
+      const departments = await client.get("/department").then(({ data }) => {
+        return data;
+      });
+
+      commit(SET_DEPARTMENTS, departments);
     },
   },
   modules: {

--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -2469,23 +2469,23 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -39,7 +39,7 @@ class TestData:
     
     def clear_db(self, session):
         for table in reversed(Base.metadata.sorted_tables):
-            session.execute(clause=table.delete())
+            session.execute(statement=table.delete())
         session.commit()
 
     def reload_data(self, db_conn):


### PR DESCRIPTION
**Issue**

Closes #419 
Closes #404 
Closes #384 
Closes #343 

**Database Changes/Migrations**

N/A

**Test Modifications**

N/A

**Test Procedure**

Do anything and nothing should break

**Photos**

N/A

**Additional Info**
This PR is to consolidate the scattered state variables into vuex. So we're talking `subsemesters`, `courses`, `departments`, `semesters`. In the future, the student course selection and some other things will need to be moved as well but we'll save that for later. 

This should fix some of the issues arising from state conflicts. 

One thing to note is that semester changes no longer go through the router, it is entirely done within vuex. This essentially deprecates the use of the query string semester option for CourseScheduler. I've left the functionality in for now for backwards compatibility, it will work on initial load, but any subsequent semester changes will not be reflected by the query string. 

The benefit to this is all components are able to access the same `selectedSemester` state. This means Explore and CourseScheduler pages are all utilizing the same `selectedSemester` and `courses` state. So any semester changes will update both accordingly. 

One final note is the use of the navigation guard for `Student` routes to load the default semester. On initial load, because the user is navigating to the page for the first time, while the navigation guard is executing, the user will be presented with a blank page. Ideally, the navigation guard logic should run almost immediately and not be erroneous. However, the best solution would be to implement 1) a loading screen for the initial navigation guard and 2) an error screen in case the initial navigation guard fails. 
