### PR TITLE
Adjusting margins

### DIFF
--- a/src/web/src/pages/CourseScheduler.vue
+++ b/src/web/src/pages/CourseScheduler.vue
@@ -75,7 +75,7 @@
         <Schedule v-else :schedule="scheduler"></Schedule>
 
         <b-row>
-          <b-col>
+          <b-col class="m-2">
             <h5>CRNs: {{ selectedCrns }}</h5>
             <h5>Credits: {{ totalCredits }}</h5>
           </b-col>
@@ -83,6 +83,7 @@
           <b-col md="3" justify="end">
             <b-row>
               <b-form-checkbox
+                class="mt-2"
                 size="sm"
                 :checked="$store.state.colorBlindAssist"
                 @change="toggleColors()"
@@ -92,7 +93,7 @@
               </b-form-checkbox>
             </b-row>
             <b-row>
-              <b-dropdown text="Export Data" class="m-2">
+              <b-dropdown text="Export Data" class="mt-2">
                 <b-dropdown-item @click="exportScheduleToIcs">
                   <font-awesome-icon :icon="exportIcon" />
                   Export To ICS


### PR DESCRIPTION
Added a margin to the color blind assist toggle so it doesn't touch the schedule grid and the left side is in line with the export data button. Also added a margin to the CRNs so they also don't touch the grid.

**Photos**

Before:
![image](https://user-images.githubusercontent.com/78986301/116757038-437b0600-a9db-11eb-851e-768c885fb6fe.png)

After:
![image](https://user-images.githubusercontent.com/78986301/116757013-352cea00-a9db-11eb-88a8-3af579742e8c.png)
