### PR TITLE
back button in course detail page now works as the browser's back button

### DIFF
--- a/src/web/src/pages/CoursePage.vue
+++ b/src/web/src/pages/CoursePage.vue
@@ -28,7 +28,8 @@
           {{ courseObj.description }}
         </b-col>
       </b-row>
-      <b-button :to="'/explore/' + courseObj.department">Back</b-button>
+      <b-button @click="$router.go(-1)">Back</b-button>
+<!--      :to="'/explore/' + courseObj.department"-->
     </div>
     <CenterSpinner
       v-else-if="isLoadingCourses"


### PR DESCRIPTION
**Issue**

The back button in course detail page leads user to the school page. People would expect to go back to where ever they came from.

**Additional Info**

Clicking the button now is essentially equal to clicking the back button in user's browser.
