### PR TITLE
Breadcrumb darkmode

### DIFF
--- a/src/web/src/assets/dark.scss
+++ b/src/web/src/assets/dark.scss
@@ -14,7 +14,6 @@
 :root {
   --dark-primary: #22252e;
   --dark-secondary: #181a21;
-  --dark-tertiary:rgba(108, 90, 90, 0.15);
   --dark-text-primary: #e6e4e4;
   --dark-text-secondary: #777777;
   --dark-border-primary: #868686;
@@ -208,7 +207,7 @@
   }
 
   .breadcrumb {
-    background-color: var(--dark-tertiary) !important;
+    background-color: var(--dark-secondary) !important;
   }
 }
 

--- a/src/web/src/assets/dark.scss
+++ b/src/web/src/assets/dark.scss
@@ -14,6 +14,7 @@
 :root {
   --dark-primary: #22252e;
   --dark-secondary: #181a21;
+  --dark-tertiary:rgba(108, 90, 90, 0.15);
   --dark-text-primary: #e6e4e4;
   --dark-text-secondary: #777777;
   --dark-border-primary: #868686;
@@ -204,6 +205,10 @@
   .modal-content {
     background: var(--dark-primary) !important;
     color: var(--dark-primary-text) !important;
+  }
+
+  .breadcrumb {
+    background-color: var(--dark-tertiary) !important;
   }
 }
 

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -88,6 +88,7 @@ export default {
         },
         {
           text: "Explore",
+          
         },
       ],
     };
@@ -140,6 +141,7 @@ export default {
   },
   metaInfo() {
     return {
+     
       title: "Explore",
       titleTemplate: "%s | YACS",
       meta: [


### PR DESCRIPTION
**Issue**

Changing the color of Breadcrumb in darkmode to match the mode better.
> closes #351 

**Database Changes/Migrations**
N/A

**Test Modifications**
N/A

**Test Procedure**
> 1. Go to yacs
> 2. Go to Explore
> 3. Change mode to dark mode

**Photos**
Show before and after, capture screenshot/gif of finished feature/bug

<img width="1379" alt="Before" src="https://user-images.githubusercontent.com/70778626/135160245-40deaaa8-b2a4-439f-aa9c-3d7ac5391100.png">
<img width="1381" alt="After" src="https://user-images.githubusercontent.com/70778626/135160248-3a4cd05d-a875-4868-8865-ca6b9366343d.png">


