### PR TITLE
SW Loop on Update

### DIFF
--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -25,6 +25,11 @@ export default {
     }
 
     this.$store.dispatch(LOAD_DEPARTMENTS);
+
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      window.location.reload();
+    });
+
   },
   methods: {
     darkModeInit() {

--- a/src/web/src/registerServiceWorker.js
+++ b/src/web/src/registerServiceWorker.js
@@ -19,10 +19,8 @@ if (process.env.NODE_ENV === "production") {
     updatefound() {
       console.log("New content is downloading.");
     },
-    updated(registration) {
+    updated() {
       console.log("New content is available; please refresh.");
-      registration.waiting.postMessage({ type: "SKIP_WAITING" });
-      window.location.reload();
     },
     offline() {
       console.log(

--- a/src/web/vue.config.js
+++ b/src/web/vue.config.js
@@ -99,9 +99,6 @@ module.exports = {
       ],
     },
     workboxPluginMode: "GenerateSW",
-    workboxOption: {
-      skipWaiting: true,
-    },
   },
   configureWebpack: {
     plugins: [new MomentLocalesPlugin()],


### PR DESCRIPTION
**Issue**
Closes #496 
Closes #509 

**Test Procedure**
- Switch to `master` and build the production.
- Visit `localhost` to register existed SW.
- Checkout to `swloop` and build the production.
- Visit `localhost`, should only refresh once now.

**Additional Info**
- The core of window refreshing moved to `App.vue`.
- Build and run your production in `localhost` with ` AUTO_LE=no SELF_CERT=yes ENABLE_BLOCK=no docker-compose -f docker-compose.yml -f docker-compose.production.yml up --build`