### PR TITLE
Adding Cron Job to update csv

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -32,3 +32,8 @@ services:
       - POSTGRES_DB=yacs
       - POSTGRES_USER=yacs
       - POSTGRES_PASSWORD=${DB_PASS:-easy_dev_pass}
+
+  yacs_update:
+    build:
+      context: ./rpi_data
+      dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,9 @@ services:
     restart: unless-stopped
     container_name: yacs_db
     image: postgres:12-alpine
+
+  yacs_update:
+    restart: unless-stopped
+    container_name: yacs_update
+    depends_on:
+      - yacs_db

--- a/rpi_data/Dockerfile
+++ b/rpi_data/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:latest
+
+# Add cron_update file in the cron directory
+ADD cron_update /etc/cron.daily/cron_update
+
+# Give execution rights on the cron job
+RUN chmod 0644 /etc/cron.d/cron_update
+
+# Create the log file to be able to run tail
+RUN touch /var/log/cron.log
+
+#Install Cron
+RUN apt-get update
+RUN apt-get -y install cron
+
+# Run the command on container startup
+CMD cron && tail -f /var/log/cron.log

--- a/rpi_data/cron_update
+++ b/rpi_data/cron_update
@@ -1,0 +1,2 @@
+0 0 * * * root ./get-spring-2022.sh
+#This is a cron job


### PR DESCRIPTION
Adding a cron job to update the csv for rpi data according to issue #505 (not sure why the pull request shows #442, i renamed it). Cron is finicky in docker containers so good luck whoever takes this over

**Issue**

#505 

*Example:*
> closes #113

**Test Modifications**

Did some testing on https://github.com/EthanTuttle/YACS-docker-testing
