### PR TITLE
Select/Remove Course in Explore page

### DIFF
--- a/src/web/src/pages/CoursePage.vue
+++ b/src/web/src/pages/CoursePage.vue
@@ -28,8 +28,13 @@
           {{ courseObj.description }}
         </b-col>
       </b-row>
-      <b-button @click="$router.go(-1)">Back</b-button>
+      <b-button @click="$router.go(-1)">Back</b-button> &nbsp;&nbsp;&nbsp;
       <!--      :to="'/explore/' + courseObj.department"-->
+
+      <b-button class="openbtn"
+                :class="{active:isActive}"
+                @click="toggle()"
+                >{{isActive ? 'Remove' : 'Select'}}</b-button>
     </div>
     <CenterSpinner
       v-else-if="isLoadingCourses"
@@ -60,6 +65,11 @@ import { COURSES } from "@/store";
 import { generateRequirementsText } from "@/utils";
 import CenterSpinnerComponent from "../components/CenterSpinner.vue";
 import CourseSectionsOpenBadge from "../components/CourseSectionsOpenBadge.vue";
+import { SelectedCoursesCookie } from "../controllers/SelectedCoursesCookie";
+import {
+  addStudentCourse,
+  removeStudentCourse,
+} from "@/services/YacsService";
 
 export default {
   components: {
@@ -69,6 +79,7 @@ export default {
   name: "CoursePage",
   data() {
     return {
+      isActive: false,
       courseName: this.$route.params.course,
       breadcrumbNav: [
         {
@@ -90,12 +101,106 @@ export default {
     };
   },
   methods: {
+    addCourse() {
+      const course = this.courseObj;
+      course.selected = true;
+      if (this.isLoggedIn) {
+        addStudentCourse({
+          name: course.name,
+          semester: this.courseObj.semester,
+          cid: "-1",
+        });
+      } else {
+        SelectedCoursesCookie.load(this.$cookies)
+          .semester(this.courseObj.semester)
+          .addCourse(course)
+          .save();
+      }
+      /*
+      course.sections.forEach((section) =>
+        this.addCourseSection(course, section)
+      );
+      */
+    },
+
+    addCourseSection(course, section) {
+      section.selected = true;
+      if (this.isLoggedIn) {
+        addStudentCourse({
+          name: course.name,
+          semester: this.courseObj.semester,
+          cid: section.crn,
+        });
+      } else {
+        SelectedCoursesCookie.load(this.$cookies)
+          .semester(this.courseObj.semester)
+          .addCourseSection(course, section)
+          .save();
+      }
+    },
+
+    removeCourse() {
+      const course = this.courseObj;
+      course.selected = false;
+
+      course.sections.forEach((section) => this.removeCourseSection(section));
+
+      if (this.isLoggedIn) {
+        removeStudentCourse({
+          name: course.name,
+          semester: this.courseObj.semester,
+          cid: null,
+        });
+      } else {
+        SelectedCoursesCookie.load(this.$cookies)
+          .semester(this.courseObj.semester)
+          .removeCourse(course)
+          .save();
+      }
+    },
+    removeCourseSection(section) {
+      if (section.selected) {
+        section.selected = false;
+
+        if (this.isLoggedIn) {
+          removeStudentCourse({
+            name: section.department + "-" + section.level,
+            semester: this.courseObj.semester,
+            cid: section.crn,
+          });
+        } else {
+          SelectedCoursesCookie.load(this.$cookies)
+            .semester(this.courseObj.semester)
+            .removeCourseSection(section)
+            .save();
+        }
+      }
+    },
+
+    toggle() {
+      if (!this.isActive) {
+        this.addCourse();
+        this.isActive = true;
+      } else {
+        this.removeCourse();
+        this.isActive = false;
+      }
+    },
+
     generateRequirementsText,
   },
   computed: {
     ...mapState(["isLoadingCourses"]),
     ...mapGetters([COURSES]),
     transformed() {
+      /*
+      const selectedCoursesCookie = SelectedCoursesCookie.load(this.$cookies);
+      console.log(selectedCoursesCookie);
+      selectedCoursesCookie.selectedCourses.forEach((selectedCourse) => {
+              const course = this.courses.find(
+                (course) => course.id === selectedCourse.id
+              );
+      */
       let precoreqtext = this.courseObj.raw_precoreqs;
       if (precoreqtext === null) {
         return "No information on pre/corequisites";
@@ -167,3 +272,14 @@ export default {
   },
 };
 </script>
+
+.openbtn {
+  font-size: 15px;
+  cursor: pointer;
+  color: #007bff;
+  border: solid #007bff;
+  background-color: transparent;
+  margin: auto;
+  display: flex;
+  text-align: center;
+}


### PR DESCRIPTION
Select/Remove Course in Explore page function added.

**Issue**

**Select Course in Explore page**
-Added a "Select" button in the 
explore page to add the course 
easily to the “Selected Courses”
-Afterwards, can check through 
“Selected Courses” located in the 
sidebar of the first screen, and 
can easily choose wanted section.

**Remove Course in Explore page**
-After press the "Select" button, 
it changes to "Remove" button.
-Added "Remove" button which 
removes the selected course
-If the course searched are already selected, 
the "Remove" button appears first.

![chrome-capture-2022-11-9](https://user-images.githubusercontent.com/112535899/206800038-6add0892-fd1c-4879-ab34-a3fb6ce3f7d3.gif)



