### PR TITLE
Update ScheduleEvent.vue

### DIFF
--- a/src/web/src/components/ScheduleEvent.vue
+++ b/src/web/src/components/ScheduleEvent.vue
@@ -96,6 +96,7 @@ export default {
     }
   }
   .event-text::-webkit-scrollbar {
+    background: var(--sb-track-color);
     width: 8px;
   }
 
@@ -104,6 +105,7 @@ export default {
   }
 
   .event-text::-webkit-scrollbar-thumb {
+    background-color: rgba(128, 128, 128, 0.7);
     background: var(--sb-thumb-color);
     border-radius: 10vw;
   }

--- a/src/web/src/components/ScheduleEvent.vue
+++ b/src/web/src/components/ScheduleEvent.vue
@@ -85,7 +85,7 @@ export default {
     font-size: 65%;
     box-sizing: border-box;
     height: 100%;
-    overflow: hidden;
+    overflow: auto;
     // // CSS Standard Scrollbar Control
     // scrollbar-width: thin;
 
@@ -94,6 +94,18 @@ export default {
       color: #000;
       font-size: 105%;
     }
+  }
+  .event-text::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .event-text::-webkit-scrollbar-track {
+    background: var(--sb-track-color);
+  }
+
+  .event-text::-webkit-scrollbar-thumb {
+    background: var(--sb-thumb-color);
+    border-radius: 10vw;
   }
 
   // // WebKit Based Scrollbar Control


### PR DESCRIPTION


**Issue**
#660
Some courses are one-hour long, and related time block will be too small to show full information. Now it is scrollable.

**Database Changes/Migrations**
Nothing changed here

Test Procedure
> 1. Go to main page
> 2. Select ADMN-1824, or other 1-hours long course
> 3. Scroll the block

**Photos**

https://user-images.githubusercontent.com/97756261/229914431-c352638d-933b-4a82-866d-fba3426cffd3.mp4


**Additional Info**


