### PR TITLE
Update Style of Hours

### DIFF
--- a/src/web/src/components/Schedule.vue
+++ b/src/web/src/components/Schedule.vue
@@ -221,7 +221,7 @@ export default {
 
 <style scoped lang="scss">
 $labelOffset: 0.35em;
-$hourFontSize: 0.5em;
+$hourFontSize: 0.8em;
 
 .schedule {
   margin-top: 10px;
@@ -248,7 +248,7 @@ $hourFontSize: 0.5em;
   position: absolute;
   width: calc(100% - #{$hourFontSize + $labelOffset + 1.75em});
   height: 100%;
-  left: 2.5em;
+  left: 3em;
 }
 
 .day-label {


### PR DESCRIPTION
**Issue**

closes #721 

**Database Changes/Migrations**

none

**Test Modifications**

none

**Test Procedure**

none

**Photos**

before:
<img width="1347" alt="Screenshot 2023-06-13 at 2 54 57 PM" src="https://github.com/YACS-RCOS/yacs.n/assets/90737103/fa8de402-92c2-44f7-a55e-9551d63d79fe">

after:
<img width="1353" alt="Screenshot 2023-06-13 at 2 51 50 PM" src="https://github.com/YACS-RCOS/yacs.n/assets/90737103/d3af142a-5959-47ff-9801-60dfd3ac3c6c">


**Additional Info**

The font size of the hours was changed and the schedule grid was shifted over a bit so that the grid lines don't overlap with the hours.
