### PR TITLE
722 improved UI on pathways page

### DIFF
--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -40,18 +40,33 @@
           </h3>
           <br />
           <div v-for="(item, itemName) in showPath" :key="itemName">
-            <h4 style="color: #3395ff; margin-top: -20px;">
-              {{ itemName + ": " }}
-            </h4>
-            <li
-              v-for="course in item"
-              :key="course"
-              v-on:click="goPage(course)"
-              class="courseInPath"
-            >
-              {{ course }}
-            </li>
-            <br />
+            <div v-if="itemName != 'Name'">
+              <h4 style="color: #3395ff; margin-top: -20px;">
+                {{ itemName + ": " }}
+              </h4>
+                <div v-if="itemName == 'Compatible minor(s)'" >
+                  <li
+                    v-for="course in item"
+                    :key="course"
+                    v-on:click="goPage(course)"
+                    class="courseInPath"
+                    style="pointer-events: none;"
+                  >
+                    {{ course }}
+                  </li>
+                </div>
+                <div v-else >
+                  <li
+                    v-for="course in item"
+                    :key="course"
+                    v-on:click="goPage(course)"
+                    class="courseInPath"
+                  >
+                    {{ course }}
+                  </li>
+                </div>
+              <br />
+            </div>
           </div>
         </div>
       </b-modal>

--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -30,7 +30,7 @@
     </div>
     <div v-if="categories.length > 0" class="mx-auto w-75">
       <!-- pop-up window -->
-      <b-modal ref="my-modal">
+      <b-modal ref="my-modal" hide-footer="true">
         <div class="block text-left" v-if="showPath != null" md="10">
           <h3
             class="text-center"
@@ -44,27 +44,27 @@
               <h4 style="color: #3395ff; margin-top: -20px;">
                 {{ itemName + ": " }}
               </h4>
-                <div v-if="itemName == 'Compatible minor(s)'" >
-                  <li
-                    v-for="course in item"
-                    :key="course"
-                    v-on:click="goPage(course)"
-                    class="courseInPath"
-                    style="pointer-events: none;"
-                  >
-                    {{ course }}
-                  </li>
-                </div>
-                <div v-else >
-                  <li
-                    v-for="course in item"
-                    :key="course"
-                    v-on:click="goPage(course)"
-                    class="courseInPath"
-                  >
-                    {{ course }}
-                  </li>
-                </div>
+              <div v-if="itemName == 'Compatible minor(s)'" >
+                <li
+                  v-for="course in item"
+                  :key="course"
+                  v-on:click="goPage(course)"
+                  class="courseInPath"
+                  style="pointer-events: none;"
+                >
+                  {{ course }}
+                </li>
+              </div>
+              <div v-else >
+                <li
+                  v-for="course in item"
+                  :key="course"
+                  v-on:click="goPage(course)"
+                  class="courseInPath"
+                >
+                  {{ course }}
+                </li>
+              </div>
               <br />
             </div>
           </div>


### PR DESCRIPTION
**Issue**

closes #722 

**Database Changes/Migrations**

None

**Test Modifications**

None

**Test Procedure**

1. Go to Pathway page.
2. Click on a pathway.
3. Hover over minor. 

**Photos**

Before:
![image](https://github.com/YACS-RCOS/yacs.n/assets/53535644/2a5f649f-1669-4258-bd11-bbee4bc8b6c2)

After:
![image](https://github.com/YACS-RCOS/yacs.n/assets/53535644/c8a7fff1-07a2-41dd-8d1c-2f53b0974b98)

**Additional Info**

Originally, there was a footer at the bottom with two buttons that said Cancel and OK. However, since the two buttons and the X at the top all close the pop up, I thought it would be best to remove both buttons.
