### PR TITLE
718 finals schedule days don't line up

### DIFF
--- a/src/web/src/pages/Calendar.vue
+++ b/src/web/src/pages/Calendar.vue
@@ -318,7 +318,7 @@ $hourFontSize: 0.5em;
   margin: 0 auto;
   margin-bottom: 3px;
   text-align: center;
-  font-size: 0.8em;
+  font-size: 0.8vw;
   font-variant: small-caps;
 }
 

--- a/src/web/src/pages/Calendar.vue
+++ b/src/web/src/pages/Calendar.vue
@@ -109,7 +109,6 @@ export default {
         STU: "Studio",
         null: "No Type",
       },
-      // dayLabels: document.querySelectorAll('.day-label')
       
     };
   },
@@ -275,14 +274,6 @@ export default {
       return (60 * 100) / this.numMinutes;
     },
 
-    // getFontSize(textLength) {
-    //   const baseFont = 9;
-    //   if (textLength >= baseFont) {
-    //     textLength = baseFont - 2;
-    //   }
-    //   const fontSize = baseFont - textLength;
-    //   return '${fontSize}vw';
-    // },
   },
   watch: {
     possibility(val) {
@@ -292,9 +283,6 @@ export default {
   },
 };
 
-// dayLabels.forEach(label => {
-//       label.style.fontSize = getFontSize(label.textContent.length);
-//     })
 </script>
 
 <style scoped lang="scss">
@@ -336,7 +324,7 @@ $hourFontSize: 0.5em;
   margin: 0 auto;
   margin-bottom: 3px;
   text-align: center;
-  font-size: 0.9vw;
+  font-size: 0.85vw;
   font-variant: small-caps;
 }
 

--- a/src/web/src/pages/Calendar.vue
+++ b/src/web/src/pages/Calendar.vue
@@ -109,6 +109,8 @@ export default {
         STU: "Studio",
         null: "No Type",
       },
+      // dayLabels: document.querySelectorAll('.day-label')
+      
     };
   },
   methods: {
@@ -153,6 +155,9 @@ export default {
     mapSessionType(type) {
       return this.sessionTypes[type] == null ? type : this.sessionTypes[type];
     },
+
+   
+    
   },
   computed: {
     hasConflict() {
@@ -269,6 +274,15 @@ export default {
     hourHeight() {
       return (60 * 100) / this.numMinutes;
     },
+
+    // getFontSize(textLength) {
+    //   const baseFont = 9;
+    //   if (textLength >= baseFont) {
+    //     textLength = baseFont - 2;
+    //   }
+    //   const fontSize = baseFont - textLength;
+    //   return '${fontSize}vw';
+    // },
   },
   watch: {
     possibility(val) {
@@ -277,6 +291,10 @@ export default {
     },
   },
 };
+
+// dayLabels.forEach(label => {
+//       label.style.fontSize = getFontSize(label.textContent.length);
+//     })
 </script>
 
 <style scoped lang="scss">
@@ -318,7 +336,7 @@ $hourFontSize: 0.5em;
   margin: 0 auto;
   margin-bottom: 3px;
   text-align: center;
-  font-size: 0.8vw;
+  font-size: 0.9vw;
   font-variant: small-caps;
 }
 


### PR DESCRIPTION
**Issue**

closes #718 

**Video After Fixing Bug**

https://github.com/YACS-RCOS/yacs.n/assets/90737103/82452909-8c81-4291-9c21-7427ef90bd90

**Additional Info**

A feature that could be implemented is making the hour labels change sizes with the day labels, which is what pull request #726 was supposed to do (make hour labels have the same size as the day labels). 
