### PR TITLE
Course conflict message

### DIFF
--- a/src/web/src/pages/Calendar.vue
+++ b/src/web/src/pages/Calendar.vue
@@ -170,6 +170,8 @@ export default {
           }
         }
       }
+      // The conflicting exam date and time should be shown here as well with 
+      // a pop up that shows which exams are conflicting and when.
       return conflicts.size > 0;
     },
     filteredExams() {

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -147,7 +147,8 @@
             <b-row>
               <b-col class="m-2">
                 <h5>CRNs: {{ selectedCrns }}</h5>
-                <h5>Credits: {{ totalCredits }}</h5>
+                <h5 v-if="scheduleDisplayMessage === 3">Credits:</h5>
+                <h5 v-else>Credits: {{ totalCredits }}</h5>
               </b-col>
 
               <b-col md="3" justify="end">

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -632,7 +632,6 @@ export default {
               if (noConflict(schedule, section)) {
                 return addSection(schedule, section);
               }
-              console.log(schedule);
               const name = schedule.sections[0].department + '-' + schedule.sections[0].level;
               if(!(this.coursesConflicting).includes(popped.name)) this.coursesConflicting.push(popped.name);
               if(!(this.coursesConflicting).includes(name)) this.coursesConflicting.push(name);

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -122,7 +122,8 @@
                   Add some sections to generate schedules!
                 </span>
                 <span v-else-if="scheduleDisplayMessage === 3">
-                  Can't display because of course conflict!
+                  
+                  Can't display because of course conflict between {{ this.coursesConflicting[0] }} and {{ this.coursesConflicting[1] }}!
 
                   <!-- new message will be "can't display because of course conflict between __ and __" -->
                   <!-- This is where the two courses that are conflicting should be displayed.
@@ -302,9 +303,7 @@ import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
 
 const noConflict = (p, section) => {
   for (let i = 0; i < 5; i++) {
-    if ((p.time[i] & section.times[i]) > 0) {
-      return false;
-    }
+    if ((p.time[i] & section.times[i]) > 0) return false;
   }
   return true;
 };
@@ -567,8 +566,8 @@ export default {
       }
     },
     getSchedules() {
-      this.showConflictMessage = false;
       this.coursesConflicting = [];
+      this.showConflictMessage = false;
       const oldLength = this.possibilities.length;
       try {
         if (Object.values(this.selectedCourses).length === 0) {
@@ -633,13 +632,10 @@ export default {
               if (noConflict(schedule, section)) {
                 return addSection(schedule, section);
               }
+              console.log(schedule);
               const name = schedule.sections[0].department + '-' + schedule.sections[0].level;
-              if(!(this.coursesConflicting).includes(popped.name)) {
-                this.coursesConflicting.push(popped.name);
-              }
-              if(!(this.coursesConflicting).includes(name)) {
-                this.coursesConflicting.push(name);
-              }
+              if(!(this.coursesConflicting).includes(popped.name)) this.coursesConflicting.push(popped.name);
+              if(!(this.coursesConflicting).includes(name)) this.coursesConflicting.push(name);
               this.coursesConflicting.sort();
               return undefined;
             })
@@ -667,10 +663,6 @@ export default {
         .updateIndex(this.index)
         .save();
     },
-    cleanConflicts() {
-      this.coursesConflicting = [ ...new Set(this.coursesConflicting) ];
-    },
-
   },
   computed: {
     ...mapState(["subsemesters", "selectedSemester"]),
@@ -727,7 +719,6 @@ export default {
       }
       return 1;
     },
-
   },
   watch: {
     courses: {

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -123,6 +123,21 @@
                 </span>
                 <span v-else-if="scheduleDisplayMessage === 3">
                   Can't display because of course conflict!
+                  <!-- This is where the two courses that are conflicting should be displayed.
+                        If scheduleDisplayMessage === 3, then pop up message should show up 
+                        right away with the two conflicting courses. -->
+                  <div class="popup" @click="closePopup">
+                    <div class="popup-content">
+                      <h2>
+                        Conflicting courses
+                      </h2>
+                      <p>
+                        The two courses <!-- course 1 and 2 --> conflict with each other. 
+                      </p>
+                    </div>
+                  </div>
+
+                  
                 </span>
                 <span v-else>
                   Displaying schedule {{ this.index + 1 }} out of
@@ -278,6 +293,7 @@ import {
 } from "@/utils";
 
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
+import Admin from './Admin.vue';
 
 const noConflict = (p, section) => {
   for (let i = 0; i < 5; i++) {
@@ -300,7 +316,8 @@ export default {
     Schedule: ScheduleComponent,
     SelectedCourses: SelectedCoursesComponent,
     CourseList: CourseListComponent,
-    CenterSpinner: CenterSpinnerComponent,
+    CenterSpinner: CenterSpinnerComponent
+    Admin,
   },
   data() {
     return {
@@ -592,6 +609,8 @@ export default {
       const popped = courses.pop();
       let ret = this.generateSchedule(courses);
 
+      // This is when the "conflict" error is thrown when there's conflicting 
+      // courses. Might be able to add something here to help show pop up. 
       if (ret.length === 0) throw new Error("conflict!");
       return ret
         .map((schedule) => {
@@ -627,6 +646,12 @@ export default {
         .semester(this.selectedSemester)
         .updateIndex(this.index)
         .save();
+    },
+    mounted() {
+      // Automatically show pop up after delay when there's a conflict
+      setTimeOut(() => {
+        this.showPopup = true;
+      }, 3000);
     },
   },
   computed: {

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -122,14 +122,7 @@
                   Add some sections to generate schedules!
                 </span>
                 <span v-else-if="scheduleDisplayMessage === 3">
-                  
-                  Can't display because of course conflict between {{ this.coursesConflicting[0] }} and {{ this.coursesConflicting[1] }}!
-
-                  <!-- new message will be "can't display because of course conflict between __ and __" -->
-                  <!-- This is where the two courses that are conflicting should be displayed.
-                        If scheduleDisplayMessage === 3, then pop up message should show up 
-                        right away with the two conflicting courses. -->
-                  
+                  Conflict between {{ this.coursesConflicting[0] }} and {{ this.coursesConflicting[1] }}
                 </span>
                 <span v-else>
                   Displaying schedule {{ this.index + 1 }} out of
@@ -187,21 +180,6 @@
         </div>
       </div>
     </b-row>
-
-    <b-modal
-      id="courseConflictModal"
-      v-if="coursesConflicting.length != 0"
-      v-model="showConflictMessage"
-      :title="'Course Conflict'" hide-footer
-    >
-
-      There is a course conflict between: 
-      <div v-for="course in coursesConflicting" :key="course">  
-        <li>{{ course }}</li>
-      </div>
-
-    </b-modal>
-
 
     <b-modal
       id="courseInfoModal"
@@ -337,7 +315,6 @@ export default {
       courseInfoModalCourse: null,
       showCourseInfoModal: false,
       coursesConflicting: [],
-      showConflictMessage: false,
       possibilities: [
         {
           sections: [],
@@ -567,7 +544,6 @@ export default {
     },
     getSchedules() {
       this.coursesConflicting = [];
-      this.showConflictMessage = false;
       const oldLength = this.possibilities.length;
       try {
         if (Object.values(this.selectedCourses).length === 0) {
@@ -582,7 +558,6 @@ export default {
           Object.values(this.selectedCourses)
         );
         if (!result.length) {
-          this.showConflictMessage = true;
           throw new Error("conflict!");
         }
         this.possibilities = result;

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -126,16 +126,18 @@
                   <!-- This is where the two courses that are conflicting should be displayed.
                         If scheduleDisplayMessage === 3, then pop up message should show up 
                         right away with the two conflicting courses. -->
-                  <div class="popup" @click="closePopup">
+                        
+                  <!--<div class="popup" @click="closePopup">
                     <div class="popup-content">
                       <h2>
                         Conflicting courses
                       </h2>
                       <p>
-                        The two courses <!-- course 1 and 2 --> conflict with each other. 
+                        The two courses course 1 and conflict with each other. 
                       </p>
                     </div>
-                  </div>
+                  </div> -->
+                
 
                   
                 </span>
@@ -293,7 +295,6 @@ import {
 } from "@/utils";
 
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
-import Admin from './Admin.vue';
 
 const noConflict = (p, section) => {
   for (let i = 0; i < 5; i++) {
@@ -316,8 +317,7 @@ export default {
     Schedule: ScheduleComponent,
     SelectedCourses: SelectedCoursesComponent,
     CourseList: CourseListComponent,
-    CenterSpinner: CenterSpinnerComponent
-    Admin,
+    CenterSpinner: CenterSpinnerComponent,
   },
   data() {
     return {
@@ -647,12 +647,12 @@ export default {
         .updateIndex(this.index)
         .save();
     },
-    mounted() {
-      // Automatically show pop up after delay when there's a conflict
-      setTimeOut(() => {
-        this.showPopup = true;
-      }, 3000);
-    },
+    // mounted() {
+    //   // Automatically show pop up after delay when there's a conflict
+    //   setTimeOut(() => {
+    //     this.showPopup = true;
+    //   }, 3000);
+    // },
   },
   computed: {
     ...mapState(["subsemesters", "selectedSemester"]),

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -126,19 +126,6 @@
                   <!-- This is where the two courses that are conflicting should be displayed.
                         If scheduleDisplayMessage === 3, then pop up message should show up 
                         right away with the two conflicting courses. -->
-                        
-                  <!--<div class="popup" @click="closePopup">
-                    <div class="popup-content">
-                      <h2>
-                        Conflicting courses
-                      </h2>
-                      <p>
-                        The two courses course 1 and conflict with each other. 
-                      </p>
-                    </div>
-                  </div> -->
-                
-
                   
                 </span>
                 <span v-else>
@@ -647,12 +634,6 @@ export default {
         .updateIndex(this.index)
         .save();
     },
-    // mounted() {
-    //   // Automatically show pop up after delay when there's a conflict
-    //   setTimeOut(() => {
-    //     this.showPopup = true;
-    //   }, 3000);
-    // },
   },
   computed: {
     ...mapState(["subsemesters", "selectedSemester"]),

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -196,8 +196,7 @@
 
       There is a course conflict between: 
       <div v-for="course in coursesConflicting" :key="course">  
-        {{ course }}
-        <br>
+        <li>{{ course }}</li>
       </div>
 
     </b-modal>
@@ -634,9 +633,14 @@ export default {
               if (noConflict(schedule, section)) {
                 return addSection(schedule, section);
               }
-              const name = schedule.section.department + '-' + schedule.section.level;
-              this.coursesConflicting.push(popped.name);
-              this.coursesConflicting.push(name);
+              const name = schedule.sections[0].department + '-' + schedule.sections[0].level;
+              if(!(this.coursesConflicting).includes(popped.name)) {
+                this.coursesConflicting.push(popped.name);
+              }
+              if(!(this.coursesConflicting).includes(name)) {
+                this.coursesConflicting.push(name);
+              }
+              this.coursesConflicting.sort();
               return undefined;
             })
             .filter((x) => !!x);


### PR DESCRIPTION
**Issue**

closes #664 

**Test Procedure**

1. Navigate towards the Schedule page
2. Select two courses with a course conflict (e.g. ARCH-2530 and ARCH-2550)

**Photos**

Before:
![image](https://github.com/YACS-RCOS/yacs.n/assets/53535644/1f74e0f8-d98b-4cc3-b067-0a4a82630868)

After:
![image](https://github.com/YACS-RCOS/yacs.n/assets/53535644/33a0de7f-11d3-4a4b-97e3-624cfd15081a)

**Additional Info**

When there is a course conflict, the courses that are conflicting will be displayed at the top where "Can't display because of course conflict!" used to be. Additionally, the credits will no longer be displayed at the bottom.
