### PR TITLE
Hover in pathways

### DIFF
--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -98,7 +98,6 @@
                       <b-button
                         @click="ShowPath(pathway)"
                         squared
-                        variant="light"
                         class="pathway-button m-0 ml-1"
                       >
                         {{ pathway["Name"][0] }}
@@ -144,7 +143,6 @@
                       <b-button
                         @click="ShowPath(pathway)"
                         squared
-                        variant="light"
                         class="pathway-button m-0 ml-1"
                       >
                         {{ pathway["Name"][0] }}
@@ -346,21 +344,29 @@ export default {
 
 .pathway-button {
   display: inline-block;
-  background: white;
+  background-color: transparent;
+  color: black;
   border-style: none;
-  text-align: justify;
+  text-align: left;
   width: 95%;
+  transition: background-color 0.01s ease-out, border-color 0.01s ease-out;
 }
 
-/* .pathway-button:hover {
+.pathway-button:hover {
+  color: black;
   background: rgba(108, 90, 90, 0.15) !important;
-} */
+  border-color: transparent;
+}
 
-.courseInPath {
-  cursor: pointer;
+.pathway-button:not(:hover) {
+  background-color: transparent;
+  color: black;
+  border-color: transparent;
+  transition-delay: 0.01s;
 }
 
 .courseInPath:hover {
+  cursor: pointer;
   background-color: rgba(39, 130, 230, 0.5);
 }
 

--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -5,7 +5,11 @@
     <!-- button to switch between alphabet order and category order -->
     <div style="float: left;" class="w-10">
       <b-button
+        class="my-button" 
+        :class="{ 'hovered': isHoveredAlphabet }"
         @click="listAlphabet()"
+        @mouseover="isHoveredAlphabet = true"
+        @mouseleave="isHoveredAlphabet = false" 
         style="
           margin-top: 10px;
           color: #007bff;
@@ -17,7 +21,11 @@
       </b-button>
       <br />
       <b-button
+        class="my-button"
+        :class="{ 'hovered': isHoveredCate }"
         @click="listCate()"
+        @mouseover="isHoveredCate = true"
+        @mouseleave="isHoveredCate = false"
         style="
           margin-top: 10px;
           color: #007bff;
@@ -171,6 +179,8 @@ export default {
   },
   data() {
     return {
+      isHoveredAlphabet: false,
+      isHoveredCate: false,
       breadcrumbNav: [
         {
           text: "YACS",
@@ -342,9 +352,9 @@ export default {
   width: 95%;
 }
 
-.pathway-button:hover {
+/* .pathway-button:hover {
   background: rgba(108, 90, 90, 0.15) !important;
-}
+} */
 
 .courseInPath {
   cursor: pointer;
@@ -352,5 +362,9 @@ export default {
 
 .courseInPath:hover {
   background-color: rgba(39, 130, 230, 0.5);
+}
+
+.hovered {
+  background-color: rgba(108, 90, 90, 0.15) !important;
 }
 </style>


### PR DESCRIPTION
**Issue**

closes #739

**Test Procedure**

1. Proceed to the Pathways page
2. Hover over the options, "List by Alphabet" and "List by Category"
3. Hover over any subject in the categories

**Photos**

Before:
<img width="627" alt="before hover" src="https://github.com/YACS-RCOS/yacs.n/assets/72230685/f3c3f6e1-a1a5-4f5c-9031-06f11a553f4a">

After: 
_hover over "List by Alphabet" option_
<img width="628" alt="after hover option" src="https://github.com/YACS-RCOS/yacs.n/assets/72230685/85c9c54e-79a6-47a6-9179-f09b664b9744">

_hover over "Electronic Art" subject_
<img width="635" alt="after hover subject" src="https://github.com/YACS-RCOS/yacs.n/assets/72230685/cac02fca-693d-421a-9054-c2a0301ae7c6">

**Additional Info**

When hovering over "List by Alphabet", "List by Category", or any subject on the page, the shade of the box will turn darker to make it more clear and aesthetically pleasing.
