### PR TITLE
Valid discord invite

### DIFF
--- a/src/web/src/components/Footer.vue
+++ b/src/web/src/components/Footer.vue
@@ -7,7 +7,7 @@
             <strong class="section-head">Contact Us</strong>
             <a
               class="link"
-              href="https://discord.gg/hTSPMr53vP"
+              href="https://discord.gg/D9PW9X79E3"
               target="_blank"
               rel="noopener"
             >


### PR DESCRIPTION
**Issue**

closes #751 

**Test Procedure**

1. Navigate to any page 
2. Scroll to the bottom of the website 
3. Under "Contact Us", click on "YACS Official Discord Server"

**Photos**

Before:
<img width="429" alt="Invalid link" src="https://github.com/YACS-RCOS/yacs.n/assets/72230685/bd23fbba-84da-40f5-8ab7-0f0096bfc4bf">

After:
<img width="419" alt="Valid link" src="https://github.com/YACS-RCOS/yacs.n/assets/72230685/8ba13089-24c0-464c-bd55-dcc4513e759e">

**Additional Info**

When trying to join the YACS official discord server, the discord link now works and will never expire. 