### PR TITLE
Schedule sticky

### DIFF
--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -6,6 +6,7 @@
     toggleable="md"
     type="primary"
     variant="light"
+    sticky="{ boundary: true }"
   >
     <b-navbar-brand
       class="align-middle text-dark"

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -912,29 +912,4 @@ button:focus {
 #burger.active .burger-bar {
   background-color: #32aad8;
 }
-
-//deleting #burger because there is already a burger button code written before this
-/*
-#burger {
-  //display: inline-block;
-
-  //position: fixed with left auto does not allow burger button to move with sidebar
-  //position: relative puts button in right location but doesnt lock when navbar is out of sight
-  position: fixed;
-  top: 12%;
-  left: 3;
-  //left: auto
-  //left: 0 puts button all the way left of page; any value >0 puts it right of the sidebar
-  transform: translateY(-50%);
-  border: 0;
-  border-radius: 0;
-  padding: 10px;
-  border-top-right-radius: 10px;
-  border-bottom-right-radius: 10px;
-  background-color: #007bff;
-  color: white;
-  z-index: 9999;
-}
-*/
-
 </style>

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -3,26 +3,27 @@
     <b-row class="h-100">
       <div v-if="isNavOpen" class="col-md-3"></div>
       <div :class="[main]">
-        <!--This is a button, an animated one-->
-        <div
-          id="burger"
-          
-          :class="{ active: isNavOpen }"
-          @click.prevent="toggleNav"
-        >
-          <slot>
-            <button type="button" class="burger-button">
-              <!--v-if="!isNavOpen"-->
-              <span class="burger-bar burger-bar--1"></span>
-              <span class="burger-bar burger-bar--2"></span>
-              <span class="burger-bar burger-bar--3"></span>
-              <span class="burger-bar burger-bar--4"></span>
-              <span class="burger-bar burger-bar--5"></span>
-              <span class="burger-bar burger-bar--6"></span>
-            </button>
-          </slot>
-        </div>
-        <div class="sidebar">
+
+        <div v-show = "!isNavOpen"
+            id="burger"
+            :class="{ active: isNavOpen }"
+            @click.prevent="toggleNav"
+            >
+
+            <slot>
+              <button type="button" class="burger-button-close">
+                <!--v-if="!isNavOpen"-->
+                <span class="burger-bar burger-bar--1"></span>
+                <span class="burger-bar burger-bar--2"></span>
+                <span class="burger-bar burger-bar--3"></span>
+                <span class="burger-bar burger-bar--4"></span>
+                <span class="burger-bar burger-bar--5"></span>
+                <span class="burger-bar burger-bar--6"></span>
+              </button>
+            </slot>
+          </div>
+
+        <div class="sidebar">  
           <!--<div class="sidebar-backdrop" v-if="isNavOpen">-->
           <transition name="slide">
             <div v-if="isNavOpen" class="sidebar-panel">
@@ -39,7 +40,8 @@
                         active
                         class="flex-grow-1 w-100"
                         data-cy="course-search-tab"
-                      >
+                      >  <!--This is a button, an animated one-->
+          
                         <b-card-text class="d-flex flex-grow-1 w-100">
                           <CenterSpinner
                             v-if="loading"
@@ -58,6 +60,26 @@
                             class="w-100"
                           />
                         </b-card-text>
+
+                        <div v-show="isNavOpen"
+                        id="burger"
+                        :class="{ active: isNavOpen }"
+                        @click.prevent="toggleNav"
+                        >
+
+                        <slot>
+                          <button type="button" class="burger-button-open">
+                            <!--v-if="!isNavOpen"-->
+                            <span class="burger-bar burger-bar--1"></span>
+                            <span class="burger-bar burger-bar--2"></span>
+                            <span class="burger-bar burger-bar--3"></span>
+                            <span class="burger-bar burger-bar--4"></span>
+                            <span class="burger-bar burger-bar--5"></span>
+                            <span class="burger-bar burger-bar--6"></span>
+                          </button>
+                        </slot>
+                      </div>
+
                       </b-tab>
                       <b-tab class="flex-grow-1" data-cy="selected-courses-tab">
                         <template v-slot:title>
@@ -822,9 +844,21 @@ button:focus {
   outline: 0;
 }
 
-.burger-button {
+.burger-button-open {
   position: relative;
   height: 30px;
+  width: 32px;
+  display: block;
+  z-index: 999;
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  pointer-events: all;
+  transition: transform 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+.burger-button-close {
+  position: fixed;
+  height: 160px;
   width: 32px;
   display: block;
   z-index: 999;
@@ -873,7 +907,7 @@ button:focus {
   transform: scale(0) rotate(45deg) translate(0px, -10px);
 }
 
-.burger-button:hover .burger-bar--1 {
+.burger-button-close:hover .burger-bar--1 {
   transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
 }
 
@@ -881,7 +915,7 @@ button:focus {
   transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
 }
 
-.burger-button:hover .burger-bar--2 {
+.burger-button-close:hover .burger-bar--2 {
   transform: scale(0.5) rotate(45deg) translate(20px, -30px);
 }
 
@@ -889,7 +923,7 @@ button:focus {
   transform: scale(0.5) rotate(45deg) translate(20px, -30px);
 }
 
-.burger-button:hover .burger-bar--5 {
+.burger-button-close:hover .burger-bar--5 {
   transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
 }
 
@@ -897,7 +931,7 @@ button:focus {
   transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
 }
 
-.burger-button:hover .burger-bar--6 {
+.burger-button-close:hover .burger-bar--6 {
   transform: scale(0.5) rotate(45deg) translate(0px, -10px);
 }
 

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -6,6 +6,7 @@
         <!--This is a button, an animated one-->
         <div
           id="burger"
+          
           :class="{ active: isNavOpen }"
           @click.prevent="toggleNav"
         >
@@ -22,7 +23,7 @@
           </slot>
         </div>
         <div class="sidebar">
-          <!--<div class="sidebar-backdrop" v-if="isNavOpen"></div>-->
+          <!--<div class="sidebar-backdrop" v-if="isNavOpen">-->
           <transition name="slide">
             <div v-if="isNavOpen" class="sidebar-panel">
               <div class="sidebar-panal-nav" style="height: 100%;">
@@ -910,5 +911,19 @@ button:focus {
 
 #burger.active .burger-bar {
   background-color: #32aad8;
+}
+
+#burger {
+  //display: inline-block;
+  position: fixed;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  padding: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
+  background-color: #007bff;
+  color: white;
+  z-index: 9999;
 }
 </style>

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -915,10 +915,17 @@ button:focus {
 
 #burger {
   //display: inline-block;
+
+  //position: fixed with left auto does not allow burger button to move with sidebar
+  //position: relative puts button in right location but doesnt lock when navbar is out of sight
   position: fixed;
-  top: 50%;
-  left: 0;
+  top: 12%;
+  left: 3;
+  //left: auto
+  //left: 0 puts button all the way left of page; any value >0 puts it right of the sidebar
   transform: translateY(-50%);
+  border: 0;
+  border-radius: 0;
   padding: 10px;
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -913,6 +913,8 @@ button:focus {
   background-color: #32aad8;
 }
 
+//deleting #burger because there is already a burger button code written before this
+/*
 #burger {
   //display: inline-block;
 
@@ -933,4 +935,6 @@ button:focus {
   color: white;
   z-index: 9999;
 }
+*/
+
 </style>

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -910,12 +910,19 @@ button:focus {
 .burger-button-close:hover .burger-bar--1 {
   transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
 }
+.burger-button-open:hover .burger-bar--1 {
+  transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
+}
 
 .no-touchevents .burger-bar--1:hover {
   transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
 }
 
 .burger-button-close:hover .burger-bar--2 {
+  transform: scale(0.5) rotate(45deg) translate(20px, -30px);
+}
+
+.burger-button-open:hover .burger-bar--2 {
   transform: scale(0.5) rotate(45deg) translate(20px, -30px);
 }
 
@@ -927,6 +934,10 @@ button:focus {
   transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
 }
 
+.burger-button-open:hover .burger-bar--5 {
+  transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
+}
+
 .no-touchevents .burger-bar--5:hover {
   transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
 }
@@ -935,11 +946,18 @@ button:focus {
   transform: scale(0.5) rotate(45deg) translate(0px, -10px);
 }
 
+.burger-button-open:hover .burger-bar--6 {
+  transform: scale(0.5) rotate(45deg) translate(0px, -10px);
+}
+
 .no-touchevents .burger-bar--6:hover {
   transform: scale(0.5) rotate(45deg) translate(0px, -10px);
 }
 
-#burger.active .burger-button {
+#burger.active .burger-button-close {
+  transform: rotateY(-540deg);
+}
+#burger.active .burger-button-open {
   transform: rotateY(-540deg);
 }
 


### PR DESCRIPTION
Closes #728
Fixed issue of the close tab button disappearing when scrolling down the page by attaching it to the course search side panel and fixing it to the top left hand corner when the panel is closed. Kept the previously implemented burger-button animation.
