### PR TITLE
Fixed clickable area of sidebar button

### DIFF
--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -821,6 +821,10 @@ button:focus {
   outline: 0;
 }
 
+#burger {
+  width: 32px;
+}
+
 .burger-button {
   position: relative;
   height: 30px;


### PR DESCRIPTION
The sidebar can now only be opened/closed when the button is clicked and not anywhere else on the page. 

closes #772 

**Test Procedure**
1. Go to Schedule page
2. Click on the space that is on the same line as the sidebar button (see video attached to issue #772 )