### PR TITLE
Fixed cut off course info on Selected Courses tab

### DIFF
--- a/src/web/src/components/SelectedCourses.vue
+++ b/src/web/src/components/SelectedCourses.vue
@@ -39,6 +39,7 @@ export default {
   flex-grow: 1;
   flex-basis: 0px; // allows flex and scroll combo
   border-bottom: 1px solid #dbdbdc;
+  padding-bottom: 40px;
 }
 .no-courses {
   margin-right: 20px;


### PR DESCRIPTION
**Issue**
closes #765 

**Test Procedure**
1. Go to the Schedule page
2. Select a bunch of courses (enough to activate scrolling on the Selected Courses tab)
3. Go to the Selected Courses tab
4. Scroll to the bottom and make sure all the information is displayed
5. Click on the dropdown menu to display the course times and make sure all of that are being displayed as well 

Before:
![Screenshot 2023-08-11 at 2 07 29 AM](https://github.com/YACS-RCOS/yacs.n/assets/90737103/1e1ca08d-773d-48df-b74e-5521d769e104)

Now:
![Screenshot 2023-08-11 at 2 02 38 AM](https://github.com/YACS-RCOS/yacs.n/assets/90737103/5fa27824-274e-418b-ac6f-837a71ad91e6)