### PR TITLE
Search prof

### DIFF
--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -3,26 +3,28 @@
     <b-row class="h-100">
       <div v-if="isNavOpen" class="col-md-3"></div>
       <div :class="[main]">
-        <!--This is a button, an animated one-->
-        <div
-          id="burger"
-          :class="{ active: isNavOpen }"
-          @click.prevent="toggleNav"
-        >
-          <slot>
-            <button type="button" class="burger-button">
-              <!--v-if="!isNavOpen"-->
-              <span class="burger-bar burger-bar--1"></span>
-              <span class="burger-bar burger-bar--2"></span>
-              <span class="burger-bar burger-bar--3"></span>
-              <span class="burger-bar burger-bar--4"></span>
-              <span class="burger-bar burger-bar--5"></span>
-              <span class="burger-bar burger-bar--6"></span>
-            </button>
-          </slot>
-        </div>
-        <div class="sidebar">
-          <!--<div class="sidebar-backdrop" v-if="isNavOpen"></div>-->
+
+        <div v-show = "!isNavOpen"
+            id="burger"
+            :class="{ active: isNavOpen }"
+            @click.prevent="toggleNav"
+            >
+
+            <slot>
+              <button type="button" class="burger-button-close">
+                <!--v-if="!isNavOpen"-->
+                <span class="burger-bar burger-bar--1"></span>
+                <span class="burger-bar burger-bar--2"></span>
+                <span class="burger-bar burger-bar--3"></span>
+                <span class="burger-bar burger-bar--4"></span>
+                <span class="burger-bar burger-bar--5"></span>
+                <span class="burger-bar burger-bar--6"></span>
+              </button>
+            </slot>
+          </div>
+
+        <div class="sidebar">  
+          <!--<div class="sidebar-backdrop" v-if="isNavOpen">-->
           <transition name="slide">
             <div v-if="isNavOpen" class="sidebar-panel">
               <div class="sidebar-panal-nav" style="height: 100%;">
@@ -38,7 +40,8 @@
                         active
                         class="flex-grow-1 w-100"
                         data-cy="course-search-tab"
-                      >
+                      >  <!--This is a button, an animated one-->
+          
                         <b-card-text class="d-flex flex-grow-1 w-100">
                           <CenterSpinner
                             v-if="loading"
@@ -57,6 +60,26 @@
                             class="w-100"
                           />
                         </b-card-text>
+
+                        <div v-show="isNavOpen"
+                        id="burger"
+                        :class="{ active: isNavOpen }"
+                        @click.prevent="toggleNav"
+                        >
+
+                        <slot>
+                          <button type="button" class="burger-button-open">
+                            <!--v-if="!isNavOpen"-->
+                            <span class="burger-bar burger-bar--1"></span>
+                            <span class="burger-bar burger-bar--2"></span>
+                            <span class="burger-bar burger-bar--3"></span>
+                            <span class="burger-bar burger-bar--4"></span>
+                            <span class="burger-bar burger-bar--5"></span>
+                            <span class="burger-bar burger-bar--6"></span>
+                          </button>
+                        </slot>
+                      </div>
+
                       </b-tab>
                       <b-tab class="flex-grow-1" data-cy="selected-courses-tab">
                         <template v-slot:title>
@@ -821,9 +844,28 @@ button:focus {
   outline: 0;
 }
 
-.burger-button {
+
+/*
+    The following is all stylistic 
+    for an animated button to close
+    the course search sidepanel
+    and holds little to no importance
+*/
+.burger-button-open {
   position: relative;
   height: 30px;
+  width: 32px;
+  display: block;
+  z-index: 999;
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  pointer-events: all;
+  transition: transform 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+.burger-button-close {
+  position: fixed;
+  height: 160px;
   width: 32px;
   display: block;
   z-index: 999;
@@ -872,7 +914,10 @@ button:focus {
   transform: scale(0) rotate(45deg) translate(0px, -10px);
 }
 
-.burger-button:hover .burger-bar--1 {
+.burger-button-close:hover .burger-bar--1 {
+  transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
+}
+.burger-button-open:hover .burger-bar--1 {
   transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
 }
 
@@ -880,7 +925,11 @@ button:focus {
   transform: scale(0.5) rotate(-45deg) translate(20px, 30px);
 }
 
-.burger-button:hover .burger-bar--2 {
+.burger-button-close:hover .burger-bar--2 {
+  transform: scale(0.5) rotate(45deg) translate(20px, -30px);
+}
+
+.burger-button-open:hover .burger-bar--2 {
   transform: scale(0.5) rotate(45deg) translate(20px, -30px);
 }
 
@@ -888,7 +937,11 @@ button:focus {
   transform: scale(0.5) rotate(45deg) translate(20px, -30px);
 }
 
-.burger-button:hover .burger-bar--5 {
+.burger-button-close:hover .burger-bar--5 {
+  transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
+}
+
+.burger-button-open:hover .burger-bar--5 {
   transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
 }
 
@@ -896,7 +949,11 @@ button:focus {
   transform: scale(0.5) rotate(-45deg) translate(0px, 10px);
 }
 
-.burger-button:hover .burger-bar--6 {
+.burger-button-close:hover .burger-bar--6 {
+  transform: scale(0.5) rotate(45deg) translate(0px, -10px);
+}
+
+.burger-button-open:hover .burger-bar--6 {
   transform: scale(0.5) rotate(45deg) translate(0px, -10px);
 }
 
@@ -904,7 +961,10 @@ button:focus {
   transform: scale(0.5) rotate(45deg) translate(0px, -10px);
 }
 
-#burger.active .burger-button {
+#burger.active .burger-button-close {
+  transform: rotateY(-540deg);
+}
+#burger.active .burger-button-open {
   transform: rotateY(-540deg);
 }
 

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -33,11 +33,11 @@
     
     <template>
       <div class="search-bar-container">
-        <input type="text" v-model="searchQuery" placeholder="Search by name or subject">
-        <button @click="searchProfessors"> <font-awesome-icon icon="search" /> </button>
+        <input type="text" v-model="searchQuery" @keyup.enter="goPage(filteredProfessors[0])" placeholder="Search by name or subject">
+        <button @click="goPage(filteredProfessors[0])" > <font-awesome-icon icon="search" /> </button>
         <div v-if="searchQuery.length == 0"></div>
         <ul v-else>
-          <div class = "result" v-for="professor in filteredProfessors" :key="professor.Name">{{ professor.Name }}</div>
+          <div class = "result" v-for="professor in filteredProfessors" :key="professor.Name" @click="goPage(professor)" >{{ professor.Name }} - {{ professor.Department }}</div>
         </ul>
       </div>
     </template>
@@ -355,11 +355,12 @@ export default {
       return ret;
     },
     filteredProfessors() {
-      const query = this.searchQuery;
+      const query = this.searchQuery.toLowerCase();
+      console.log(query);
       return this.professors.filter(
         professor =>
-          professor.Name.includes(query) ||
-          professor.Department.includes(query)
+          professor.Name.toLowerCase().includes(query) ||
+          professor.Department.toLowerCase().includes(query)
       );
     },
   },
@@ -387,10 +388,15 @@ export default {
       this.$router.push("/professor/" + rcs);
     },
     searchProfessors() {
+      professor = this.filteredProfessors[0];
+      console.log(professor);
+      var rcs = professor["Email"].replace("@rpi.edu", "");
+      this.$router.push("/professor/" + rcs);
     },
   },
 };
 </script>
+
 
 <style>
 .gridContainer {
@@ -418,6 +424,7 @@ export default {
 
 .professor-button:hover {
   background: rgba(108, 90, 90, 0.15) !important;
+
 }
 
 .search-bar-container {
@@ -445,11 +452,16 @@ export default {
 .search-bar-container .result{
   color: white;
   background-color: rgba(108, 90, 90, 0.15);
-  margin-left: 10%;
-  width: 71.8%;
+  margin-left: 133px;
+  width: 72%;
   padding: 10px;
   border: 2px solid;
-  border-color: hsl(211, 100%, 60%);;
+  border-color: rgba(108, 90, 90, 0.15);
+  
+}
+.search-bar-container .result:hover{
+  color: hsl(211, 100%, 60%);
+  cursor: pointer;
 }
 
 

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -37,7 +37,7 @@
         <button @click="goPage(filteredProfessors[0])" > <font-awesome-icon icon="search" /> </button>
         <div v-if="searchQuery.length == 0"></div>
         <ul v-else>
-          <div class = "result" v-for="professor in filteredProfessors" :key="professor.Name" @click="goPage(professor)" >{{ professor.Name }} - {{ professor.Department }}</div>
+          <div class = "result" v-for="professor in sortedProfSearch" :key="professor.Name" @click="goPage(professor)" >{{ professor.Name }} - {{ professor.Department }}</div>
         </ul>
       </div>
     </template>
@@ -197,6 +197,7 @@ export default {
       deptShow: false,
       alphShow: true,
       searchQuery: '',
+      searchResult: []
     };
   },
   computed: {
@@ -357,12 +358,18 @@ export default {
     filteredProfessors() {
       const query = this.searchQuery.toLowerCase();
       console.log(query);
-      return this.professors.filter(
+      this.searchResult = this.professors.filter(
         professor =>
           professor.Name.toLowerCase().includes(query) ||
           professor.Department.toLowerCase().includes(query)
       );
+      return this.searchResult
     },
+    sortedProfSearch(){
+      return this.filteredProfessors.slice().sort((a, b) => {
+        return a.Name.localeCompare(b.Name);
+      });
+    }
   },
 
   methods: {

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -7,7 +7,7 @@
       <b-button
         @click="listAlphabet()"
         style="
-          margin-top: 10px;
+          margin-top: 65px;
           color: #007bff;
           border: solid #007bff;
           background-color: transparent;
@@ -30,7 +30,16 @@
         List by Department
       </b-button>
     </div>
+    
+    <template>
+      <div class="search-bar-container">
+        <input type="text" v-model="searchQuery" placeholder="Search by name or subject">
+        <button @click="searchProfessors"> <font-awesome-icon icon="search" /> </button>
+        <div v-if="professors.length === 0">No professors found.</div>
 
+      </div>
+    </template>
+    
     <div v-if="professors.length > 0" class="mx-auto w-75">
       <!-- pop-up window -->
       <b-modal ref="my-modal">
@@ -366,6 +375,8 @@ export default {
       var rcs = professor["Email"].replace("@rpi.edu", "");
       this.$router.push("/professor/" + rcs);
     },
+    searchProfessors() {
+    },
   },
 };
 </script>
@@ -397,6 +408,29 @@ export default {
 .professor-button:hover {
   background: rgba(108, 90, 90, 0.15) !important;
 }
+
+.search-bar-container {
+  padding: 10px;
+  text-align: left;
+}
+
+.search-bar-container input {
+  margin-left: 18px;
+  width: 70%;
+  padding: 5px;
+  font-size: 16px;
+}
+.search-bar-container button {
+  padding: 5px;
+  color: hsl(211, 100%, 60%);
+  background-color: transparent;
+  box-shadow: none;
+  border: 2px solid
+}
+.search-bar-container button:hover {
+  color: white;
+}
+
 
 .h3 {
   text-align: left;

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -32,11 +32,13 @@
     </div>
     
     <template>
-      <div class="search-bar-container" v-for="search in searchProfessors()" :key=search>
-        <input type="text" v-model="input" placeholder="Search by name or subject">
-        <p>{{ search }}</p>
+      <div class="search-bar-container">
+        <input type="text" v-model="searchQuery" placeholder="Search by name or subject">
         <button @click="searchProfessors"> <font-awesome-icon icon="search" /> </button>
-
+        <div v-if="searchQuery.length == 0"></div>
+        <ul v-else>
+          <div class = "result" v-for="professor in filteredProfessors" :key="professor.Name">{{ professor.Name }}</div>
+        </ul>
       </div>
     </template>
     
@@ -173,8 +175,6 @@
 <script>
 import json from "./Professors.json";
 import CenterSpinnerComponent from "../components/CenterSpinner";
-import { ref } from "vue";
-let input = ref("");
 
 export default {
   name: "Professor",
@@ -196,6 +196,7 @@ export default {
       showProf: null,
       deptShow: false,
       alphShow: true,
+      searchQuery: '',
     };
   },
   computed: {
@@ -353,6 +354,14 @@ export default {
       ret.push(col2);
       return ret;
     },
+    filteredProfessors() {
+      const query = this.searchQuery;
+      return this.professors.filter(
+        professor =>
+          professor.Name.includes(query) ||
+          professor.Department.includes(query)
+      );
+    },
   },
 
   methods: {
@@ -378,10 +387,6 @@ export default {
       this.$router.push("/professor/" + rcs);
     },
     searchProfessors() {
-      profs = ["a","b", "c"];
-      return profs.filter((search) =>
-      fruit.toLowerCase().includes(input.value.toLowerCase())
-    );
     },
   },
 };
@@ -435,6 +440,16 @@ export default {
 }
 .search-bar-container button:hover {
   color: white;
+}
+
+.search-bar-container .result{
+  color: white;
+  background-color: rgba(108, 90, 90, 0.15);
+  margin-left: 10%;
+  width: 71.8%;
+  padding: 10px;
+  border: 2px solid;
+  border-color: hsl(211, 100%, 60%);;
 }
 
 

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -32,10 +32,10 @@
     </div>
     
     <template>
-      <div class="search-bar-container">
-        <input type="text" v-model="searchQuery" placeholder="Search by name or subject">
+      <div class="search-bar-container" v-for="search in searchProfessors()" :key=search>
+        <input type="text" v-model="input" placeholder="Search by name or subject">
+        <p>{{ search }}</p>
         <button @click="searchProfessors"> <font-awesome-icon icon="search" /> </button>
-        <div v-if="professors.length === 0">No professors found.</div>
 
       </div>
     </template>
@@ -173,6 +173,8 @@
 <script>
 import json from "./Professors.json";
 import CenterSpinnerComponent from "../components/CenterSpinner";
+import { ref } from "vue";
+let input = ref("");
 
 export default {
   name: "Professor",
@@ -376,6 +378,10 @@ export default {
       this.$router.push("/professor/" + rcs);
     },
     searchProfessors() {
+      profs = ["a","b", "c"];
+      return profs.filter((search) =>
+      fruit.toLowerCase().includes(input.value.toLowerCase())
+    );
     },
   },
 };


### PR DESCRIPTION
**Issue**
There are a lot of professors to look through in the professors page and scrolling through would take too long. A search bar allows for users to search for specific professors or departments narrowing their search. Clicking on the results would then go to the corresponding page for that professors information.

> closes #762 

**Photos**

Show before and after, capture screenshot/gif of finished feature/bug

<img width="1440" alt="Screen Shot 2023-08-11 at 2 34 29 PM" src="https://github.com/YACS-RCOS/yacs.n/assets/112728552/01a0310d-780d-41f8-bd21-3c1476e41491">
<img width="1440" alt="Screen Shot 2023-08-11 at 2 34 55 PM" src="https://github.com/YACS-RCOS/yacs.n/assets/112728552/5dd2461a-e34f-4316-85e6-27a9b2b20c02">
<img width="1440" alt="Screen Shot 2023-08-11 at 2 35 11 PM" src="https://github.com/YACS-RCOS/yacs.n/assets/112728552/f4e26e70-70d4-44f0-8624-190e528793c7">

