### PR TITLE
715 components on finals page showing lines upon refresh

### DIFF
--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -17,7 +17,7 @@
                 ></b-form-select>
               </b-form-group>
             </div>
-            <b-button @click="addCourse" variant="primary">Add Course</b-button>
+            <b-button @click="addCourse" variant="primary">ADDDDDDDDD Course</b-button>
             <b-button type="submit" variant="success" class="ml-3">
               Search
             </b-button>

--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -22,7 +22,7 @@
               Search
             </b-button>
           </b-form>
-          <b-card v-if="examDetails" class="mt-3">
+          <b-card v-if="examDetails" class="mt-3 border-0">
             <h5 class="card-title">Exam Details</h5>
             <div v-for="exam in examDetails" :key="exam.id">
               <div>

--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -17,7 +17,7 @@
                 ></b-form-select>
               </b-form-group>
             </div>
-            <b-button @click="addCourse" variant="primary">ADDDDDDDDD Course</b-button>
+            <b-button @click="addCourse" variant="primary">Add Course</b-button>
             <b-button type="submit" variant="success" class="ml-3">
               Search
             </b-button>

--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -3,7 +3,7 @@
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
     <b-row class="justify-content-md-center">
       <b-col md="5">
-        <b-card title="Final Exam Schedule">
+        <b-card title="Final Exam Schedule" class="card border-0">
           <b-form @submit.prevent="searchExams">
             <div
               v-for="(course, index) in selectedCourses"


### PR DESCRIPTION
**Issue**
> closes #113 

**Test Procedure**
1. Proceed to the Finals page.
2. Do not refresh, check to see if there is an outline.
3. If there is no outline, refresh, and see if an outline appears. 
4. If no outline at all, then the fix works correctly.

**Photos**

BEFORE:
<img width="580" alt="image" src="https://github.com/YACS-RCOS/yacs.n/assets/74884278/3cc7c20e-fafb-4a14-b3a8-63237f5dfb1a">

AFTER:
<img width="580" alt="image" src="https://github.com/YACS-RCOS/yacs.n/assets/74884278/bdd27af4-e947-4b87-9fc5-8e1b2aa2f625">

**Additional Info**

This was fixed by someone else but the pull request was never created.