### PR TITLE
highlight conflicting course sections

### DIFF
--- a/src/web/src/components/CourseListing.vue
+++ b/src/web/src/components/CourseListing.vue
@@ -53,8 +53,8 @@
                 ? `4px solid ${getBorderColor(course.name)}`
                 : 'none',
               'background-color': section.selected
-                ? `${getBackgroundColor(course.name)} !important`
-                : $store.state.darkMode
+                ? `${getColor(section.crn, conflictingCrns)}`
+                : $store.state.darkMode 
                 ? 'var(--dark-primary)'
                 : 'white',
               color: section.selected
@@ -124,6 +124,7 @@ export default {
   },
   props: {
     course: Object,
+    conflictingCrns: Array,
     // If true, collapse is open when created
     // If lazyLoadCollapse is true, this is ignored
     openInitial: {
@@ -174,6 +175,22 @@ export default {
     readableDate,
     getBackgroundColor,
     getBorderColor,
+
+    getColor(course, conflicts) {
+      if (this.isConflict(course,conflicts)) {
+        return '#7B0808 !important'
+      }
+      return `${getBackgroundColor(this.course.name)} !important`
+    },
+    isConflict(course,conflicts) {
+      for (var i = 0; i < conflicts.length; i++) {
+        if (course===String(conflicts[i])) {
+          return true;
+        }
+      }
+      return false;
+    },
+
     // Just a wrapper, can't call `[defaultAction]()` in html
     callDefaultAction() {
       this[this.defaultAction]();

--- a/src/web/src/components/SelectedCourses.vue
+++ b/src/web/src/components/SelectedCourses.vue
@@ -10,7 +10,7 @@
       v-for="course of courses"
       :key="course.id"
     >
-      <CourseListing :course="course" v-on="$listeners" />
+      <CourseListing :course="course" v-bind:conflictingCrns="conflictingCrns" v-on="$listeners" />
     </b-list-group-item>
   </b-list-group>
 </template>
@@ -27,6 +27,7 @@ export default {
   },
   props: {
     courses: Object,
+    conflictingCrns: Array,
   },
 };
 </script>


### PR DESCRIPTION
**Issue**

closes #794

**Test Procedure**

1. Add 2 or more courses that have conflicting schedules.
2. Go to the "selected courses" tab and expand a course.
3. You should be able to see conflicting courses highlighted as red.

**Photos**

before:
<img width="184" alt="image" src="https://github.com/YACS-RCOS/yacs.n/assets/119146767/1c4fcfd9-17fd-4b81-a098-00270e39bcd9">
after:
<img width="187" alt="image" src="https://github.com/YACS-RCOS/yacs.n/assets/119146767/332394ec-088f-411f-8aef-0e6ab3992056">
