### PR TITLE
730 add from explore page

### DIFF
--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -304,7 +304,6 @@ export default {
   },
   data() {
     return {
-      selectedCourses: {},
       selectedScheduleSubsemester: null,
       scheduler: null,
       exportIcon: faPaperPlane,
@@ -534,11 +533,15 @@ export default {
      * Toggle course selected state
      * Emits removeCourse and addCourse events
      */
-    toggleCourse(course) {
+     toggleCourse(course) {
       if (course.selected) {
-        this.removeCourse(course);
+        // Remove course
+        this.$store.dispatch('removeCourse', course.id);
+        // Additional logic (e.g., also remove sections associated with the course) can go here.
       } else {
-        this.addCourse(course);
+        // Add course
+        this.$store.dispatch('addCourse', course);
+        // Additional logic (e.g., also add sections associated with the course) can go here.
       }
     },
     getSchedules() {
@@ -633,6 +636,7 @@ export default {
     ...mapState(["subsemesters", "selectedSemester"]),
     ...mapGetters([COURSES]),
     ...mapGetters({ isLoggedIn: userTypes.getters.IS_LOGGED_IN }),
+    ...mapGetters(['selectedCourses']),
 
     loading() {
       return this.$store.state.isLoadingCourses;

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -130,7 +130,6 @@ export default {
   },
   data() {
     return {
-      selectedCourses: {},
       subject: this.$route.params.subject, // subject object from CourseExplorer
       breadcrumbNav: [
         {
@@ -344,14 +343,19 @@ export default {
      * Toggle course selected state
      * Emits removeCourse and addCourse events
      */
-    toggleCourse(course) {
-      if (course.selected) {
-        this.removeCourse(course);
-      } else {
-        this.addCourse(course);
-      }
-      console.log(course);
-    },
+     toggleCourse(course) {
+        if (course.selected) {
+          // Remove course
+          this.removeCourse(course);
+          this.$store.dispatch('removeCourse', course);
+          // Additional logic (e.g., also remove sections associated with the course) can go here.
+        } else {
+          // Add course
+          this.addCourse(course);
+          this.$store.dispatch('addCourse', course);
+          // Additional logic (e.g., also add sections associated with the course) can go here.
+        }
+      },
     getSchedules() {
       const oldLength = this.possibilities.length;
       try {
@@ -416,6 +420,7 @@ export default {
   computed: {
     ...mapState(["isLoadingCourses"]),
     ...mapGetters(["courses"]),
+    ...mapGetters(['selectedCourses']),
     //courseColumns[0] corresponds to left column, [1] to right column
     courseColumns() {
       let leftColumn = [];

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -159,7 +159,7 @@ export default {
     toggleColors() {
       this.$store.commit(TOGGLE_COLOR_BLIND_ASSIST);
     },
-
+    
     async loadStudentCourses() {
       if (!this.courses.length) {
         return;
@@ -258,6 +258,9 @@ export default {
         selectedIndexCookie.clear().save();
       }
       this.loadedIndexCookie = 1;
+    },
+    mounted(){
+      this.loadStudentCourses();
     },
     addCourse(course) {
       this.$set(this.selectedCourses, course.id, course);

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -32,6 +32,15 @@
                 {{ course.level }}
               </span>
               <course-sections-open-badge :course="course" />
+              <!-- Add the transparent button to add/remove courses -->
+              <b-button
+                variant="outline-primary"  
+                size="sm"  
+                class="transparent-button"
+                @click.prevent="toggleCourse(course)"
+              >
+              {{ course.selected ? '✕' : '+' }}
+              </b-button>
             </b-button>
           </b-col>
         </b-row>
@@ -62,6 +71,15 @@
                 {{ course.level }}
               </span>
               <course-sections-open-badge :course="course" />
+              <!-- Add the transparent button to add/remove courses -->
+              <b-button
+                variant="outline-primary"  
+                size="sm"  
+                class="transparent-button"
+                @click.prevent="toggleCourse(course)"
+              >
+                {{ course.selected ? '✕' : '+' }}
+              </b-button>
             </b-button>
           </b-col>
         </b-row>
@@ -83,6 +101,24 @@ import { mapGetters, mapState } from "vuex";
 import CenterSpinnerComponent from "../components/CenterSpinner";
 import CourseSectionsOpenBadge from "../components/CourseSectionsOpenBadge.vue";
 
+import SubSemesterScheduler from "@/controllers/SubSemesterScheduler";
+
+import { SelectedCoursesCookie } from "../controllers/SelectedCoursesCookie";
+import { SelectedIndexCookie } from "../controllers/SelectedIndexCookie";
+
+
+import { TOGGLE_COLOR_BLIND_ASSIST } from "@/store";
+
+import {
+  addStudentCourse,
+  getStudentCourses,
+  removeStudentCourse,
+} from "@/services/YacsService";
+
+import {
+  withinDuration,
+} from "@/utils";
+
 export default {
   name: "SubjectExplorer",
   components: {
@@ -91,6 +127,7 @@ export default {
   },
   data() {
     return {
+      selectedCourses: {},
       subject: this.$route.params.subject, // subject object from CourseExplorer
       breadcrumbNav: [
         {
@@ -108,7 +145,271 @@ export default {
       ],
     };
   },
-  methods: {},
+  methods: {
+    toggleNav() {
+      this.isNavOpen = !this.isNavOpen;
+      if (this.isNavOpen) {
+        this.main = "col-md-9";
+      } else {
+        this.main = "col-md-12";
+      }
+    },
+    toggleColors() {
+      this.$store.commit(TOGGLE_COLOR_BLIND_ASSIST);
+    },
+
+    async loadStudentCourses() {
+      if (!this.courses.length) {
+        return;
+      }
+
+      this.scheduler = new SubSemesterScheduler();
+      // Filter out "full" subsemester
+      this.subsemesters
+        .filter(
+          (s, i, arr) =>
+            arr.length == 1 ||
+            !arr.every((o, oi) => oi == i || withinDuration(s, o))
+        )
+        .forEach((subsemester) => {
+          this.scheduler.addSubSemester(subsemester);
+        });
+
+      if (this.scheduler.scheduleSubsemesters.length > 0) {
+        this.selectedScheduleSubsemester = this.scheduler.scheduleSubsemesters[0].display_string;
+      }
+
+      // Need to reset `selected` property on courses and sections,
+      // two sources of truth ugh
+      Object.values(this.selectedCourses).forEach((course) => {
+        course.selected = false;
+
+        course.sections
+          .filter((section) => section.selected)
+          .forEach((section) => (section.selected = false));
+      });
+      this.selectedCourses = {};
+
+      if (this.isLoggedIn) {
+        var cids = await getStudentCourses();
+
+        cids.forEach((cid) => {
+          if (cid.semester == this.selectedSemester) {
+            var c = this.courses.find(function (course) {
+              return (
+                course.name == cid.course_name &&
+                course.semester == cid.semester
+              );
+            });
+
+            if (cid.crn != "-1") {
+              var sect = c.sections.find(function (section) {
+                return section.crn == cid.crn;
+              });
+              sect.selected = true;
+            } else {
+              c.selected = true;
+              this.$set(this.selectedCourses, c.id, c);
+            }
+          }
+        });
+      } else {
+        const selectedCoursesCookie = SelectedCoursesCookie.load(this.$cookies);
+
+        try {
+          selectedCoursesCookie
+            .semester(this.selectedSemester)
+            .selectedCourses.forEach((selectedCourse) => {
+              const course = this.courses.find(
+                (course) => course.id === selectedCourse.id
+              );
+
+              this.$set(this.selectedCourses, course.id, course);
+              course.selected = true;
+
+              selectedCourse.selectedSectionCrns.forEach(
+                (selectedSectionCrn) => {
+                  const section = course.sections.find(
+                    (section) => section.crn === selectedSectionCrn
+                  );
+
+                  section.selected = true;
+                }
+              );
+            });
+        } catch (err) {
+          // If there is an error here, it might mean the data was changed,
+          //  thus we need to reload the cookie
+          selectedCoursesCookie.clear().save();
+        }
+      }
+
+      const selectedIndexCookie = SelectedIndexCookie.load(this.$cookies);
+
+      try {
+        this.index = selectedIndexCookie.semester(
+          this.selectedSemester
+        ).selectedIndex;
+      } catch (err) {
+        // If there is an error here, it might mean the data was changed,
+        //  thus we need to reload the cookie
+        selectedIndexCookie.clear().save();
+      }
+      this.loadedIndexCookie = 1;
+    },
+    addCourse(course) {
+      this.$set(this.selectedCourses, course.id, course);
+      course.selected = true;
+      if (this.isLoggedIn) {
+        addStudentCourse({
+          name: course.name,
+          semester: this.selectedSemester,
+          cid: "-1",
+        });
+      } else {
+        SelectedCoursesCookie.load(this.$cookies)
+          .semester(this.selectedSemester)
+          .addCourse(course)
+          .save();
+      }
+      course.sections.forEach((section) =>
+        this.addCourseSection(course, section)
+      );
+    },
+    addCourseSection(course, section) {
+      section.selected = true;
+      if (this.isLoggedIn) {
+        addStudentCourse({
+          name: course.name,
+          semester: this.selectedSemester,
+          cid: section.crn,
+        });
+      } else {
+        SelectedCoursesCookie.load(this.$cookies)
+          .semester(this.selectedSemester)
+          .addCourseSection(course, section)
+          .save();
+      }
+    },
+    removeCourse(course) {
+      this.$delete(this.selectedCourses, course.id);
+      course.selected = false;
+
+      course.sections.forEach((section) => this.removeCourseSection(section));
+
+      if (this.isLoggedIn) {
+        removeStudentCourse({
+          name: course.name,
+          semester: this.selectedSemester,
+          cid: null,
+        });
+      } else {
+        SelectedCoursesCookie.load(this.$cookies)
+          .semester(this.selectedSemester)
+          .removeCourse(course)
+          .save();
+      }
+    },
+    removeCourseSection(section) {
+      if (section.selected) {
+        section.selected = false;
+
+        if (this.isLoggedIn) {
+          removeStudentCourse({
+            name: section.department + "-" + section.level,
+            semester: this.selectedSemester,
+            cid: section.crn,
+          });
+        } else {
+          SelectedCoursesCookie.load(this.$cookies)
+            .semester(this.selectedSemester)
+            .removeCourseSection(section)
+            .save();
+        }
+      }
+    },
+
+    /**
+     * @param {Course} course
+     */
+    showCourseInfo(course) {
+      this.courseInfoModalCourse = course;
+      this.showCourseInfoModal = true;
+    },
+
+    /**
+     * Toggle course selected state
+     * Emits removeCourse and addCourse events
+     */
+    toggleCourse(course) {
+      if (course.selected) {
+        this.removeCourse(course);
+      } else {
+        this.addCourse(course);
+      }
+      course.selected = !course.selected; // Toggle the selected state
+    },
+    getSchedules() {
+      const oldLength = this.possibilities.length;
+      try {
+        if (Object.values(this.selectedCourses).length === 0) {
+          this.possibilities = [
+            {
+              sections: [],
+              time: [0, 0, 0, 0, 0],
+            },
+          ];
+        }
+        const result = this.generateSchedule(
+          Object.values(this.selectedCourses)
+        );
+        if (!result.length) {
+          throw new Error("conflict!");
+        }
+        this.possibilities = result;
+
+        //Don't set this.index to 0 if just loaded cookie
+        if (this.loadedIndexCookie == 2) {
+          if (oldLength != this.possibilities.length) {
+            this.index = 0;
+            this.updateIndexCookie();
+          }
+        } else if (this.loadedIndexCookie == 1) {
+          this.loadedIndexCookie = 2;
+        }
+      } catch (e) {
+        console.log(e.message);
+        this.possibilities = [
+          {
+            sections: [],
+            time: [0, 0, 0, 0, 0],
+            conflict: e.message === "conflict!",
+          },
+        ];
+      }
+    },
+    
+    changeSchedule(step) {
+      const l = this.possibilities.length;
+      if (l === 0) return;
+      const c = this.index + step;
+      if (c < 0) {
+        this.index = l - 1;
+        return;
+      }
+      if (c >= l) {
+        this.index = 0;
+        return;
+      }
+      this.index = c;
+    },
+    updateIndexCookie() {
+      SelectedIndexCookie.load(this.$cookies)
+        .semester(this.selectedSemester)
+        .updateIndex(this.index)
+        .save();
+    },
+  },
   computed: {
     ...mapState(["isLoadingCourses"]),
     ...mapGetters(["courses"]),
@@ -189,5 +490,16 @@ export default {
 
 .courseBox:hover {
   background: rgba(108, 90, 90, 0.15) !important;
+}
+
+.transparent-button {
+  left: 100px;
+  top: 5px;
+  right: 5px;
+  
+  background-color: transparent;
+  border: none;
+  color: #007bff; /* Change the color to match your design */
+  cursor: pointer;
 }
 </style>

--- a/src/web/src/pages/SubjectExplorer.vue
+++ b/src/web/src/pages/SubjectExplorer.vue
@@ -1,11 +1,14 @@
 <template>
+  
   <b-container fluid>
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
+    
     <b-row class="justify-content-center">
       <!-- The subject title should be depending on the input parameter from subjectList.vue -->
       <h3 class="subjectBox">{{ subject }}</h3>
     </b-row>
     <!-- left column of courses -->
+    
     <b-row v-if="!isLoadingCourses && courses.length > 0">
       <b-col cols="6">
         <b-row
@@ -347,7 +350,7 @@ export default {
       } else {
         this.addCourse(course);
       }
-      course.selected = !course.selected; // Toggle the selected state
+      console.log(course);
     },
     getSchedules() {
       const oldLength = this.possibilities.length;

--- a/src/web/src/store/index.js
+++ b/src/web/src/store/index.js
@@ -48,6 +48,7 @@ const store = new Vuex.Store({
     semesters: [],
     subsemesters: [],
     departments: [],
+    selectedCourses: {},
   },
   getters: {
     [COURSES]: (state) => Object.values(state.coursesById),
@@ -58,6 +59,7 @@ const store = new Vuex.Store({
     colorBlindAssistState: (state) => {
       return state.colorBlindAssist;
     },
+    selectedCourses: state => state.selectedCourses,
   },
   mutations: {
     [TOGGLE_DARK_MODE](state, isDarkMode = null) {
@@ -120,6 +122,12 @@ const store = new Vuex.Store({
     },
     [SET_SEMESTERS](state, semesters) {
       state.semesters = semesters;
+    },
+    ADD_COURSE(state, course) {
+      Vue.set(state.selectedCourses, course.id, course);
+    },
+    REMOVE_COURSE(state, course) {
+      Vue.delete(state.selectedCourses, course.id, course);
     },
   },
   actions: {
@@ -209,6 +217,12 @@ const store = new Vuex.Store({
       });
 
       commit(SET_DEPARTMENTS, departments);
+    },
+    addCourse({commit},course){
+      commit('ADD_COURSE',course);
+    },
+    removeCourse({commit, course}){
+      commit('REMOVE_COURSE',course);
     },
   },
   modules: {

--- a/src/web/src/store/index.js
+++ b/src/web/src/store/index.js
@@ -221,9 +221,10 @@ const store = new Vuex.Store({
     addCourse({commit},course){
       commit('ADD_COURSE',course);
     },
-    removeCourse({commit, course}){
-      commit('REMOVE_COURSE',course);
+    removeCourse({commit}, course){
+      commit('REMOVE_COURSE', course);
     },
+   
   },
   modules: {
     [USER_NAMESPACE]: userModule,


### PR DESCRIPTION
Test Procedure:

1)  Add a button in Explore that allows users to add classes.
2)  When the user clicks the button the user can add the class and when user clicks the button again it removes the class
p.s there are some bugs but I do not know how to fix it. The classes selected don't save when refreshed.

Pictures:

[before:]
![x](https://github.com/YACS-RCOS/yacs.n/assets/37049496/032bc113-843f-4d8c-a278-04f49811d767)
[after:]

![x1](https://github.com/YACS-RCOS/yacs.n/assets/37049496/a7600be1-3400-4516-b089-525d0b8872c7)

