### PR TITLE
785 feature request copy crns

### DIFF
--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -147,7 +147,7 @@
             <b-row>
               <b-col class="m-2">
                 <div style="display: inline-block;">
-                  <h5 style="display: inline; margin: 0;">CRNs:</h5>
+                  <h5 style="display: inline; margin: 0;">CRNs: </h5>
                   <span v-for="(crn, index) in getCrns" :key="index">
                     <h5
                       @click="copyToClipboard(crn)"

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -146,7 +146,10 @@
 
             <b-row>
               <b-col class="m-2">
-                <h5>CRNs: {{ selectedCrns }}</h5>
+                <h5>CRNs:</h5>
+                <div v-for="crn in crns" :key="crn">
+                  <span @click="copyToClipboard(crn)" style="cursor: pointer;">{{ crn }}</span>
+                </div>
                 <h5>Credits: {{ totalCredits }}</h5>
               </b-col>
 
@@ -628,6 +631,19 @@ export default {
         .updateIndex(this.index)
         .save();
     },
+
+    copyToClipboard(crn) {
+      navigator.clipboard.writeText(crn)
+        .then(() => {
+          this.showCopyConfirmation();
+        })
+        .catch((err) => {
+          console.error('Unable to copy to clipboard: ', err);
+        });
+    },
+    showCopyConfirmation() {
+      alert("CRN copied to clipboard!");
+    },
   },
   computed: {
     ...mapState(["subsemesters", "selectedSemester"]),
@@ -648,16 +664,14 @@ export default {
         .map((c) => c.sections.filter((s) => s.selected))
         .flat();
     },
+    
     /**
-     * Returns list of CRNs for all selected sections
-     * @returns {string}
+     * Generate an array of CRNs from this.possibilities[this.index].sections
      */
-    selectedCrns() {
-      return (
-        this.possibilities[this.index] &&
-        this.possibilities[this.index].sections.map((s) => s.crn).join(", ")
-      );
+    crns() {
+      return this.possibilities[this.index].sections.map((s) => s.crn);
     },
+
     /**
      * Returns sum of credits being taken from all selected sections
      */

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -145,10 +145,20 @@
             <Schedule v-else :possibility="possibilities[index]"></Schedule>
 
             <b-row>
-              <b-col class="m-2">
+              <!-- <b-col class="m-2">
                 <h5>CRNs:</h5>
-                <div v-for="crn in crns" :key="crn">
+                <div v-for="crn in getCrns" :key="crn">
                   <span @click="copyToClipboard(crn)" style="cursor: pointer;">{{ crn }}</span>
+                </div>
+                <h5>Credits: {{ totalCredits }}</h5>
+              </b-col> -->
+              <b-col class="m-2">
+                <div style="display: inline-block;">
+                  <h5 style="display: inline; margin: 0;">CRNs: </h5>
+                  <span v-for="(crn, index) in getCrns" :key="index">
+                    <h5 @click="copyToClipboard(crn)" style="cursor: pointer; display: inline; margin: 0; padding: 0;">{{ crn }}</h5>
+                    <span v-if="index !== getCrns.length - 1">, </span>
+                  </span>
                 </div>
                 <h5>Credits: {{ totalCredits }}</h5>
               </b-col>
@@ -668,7 +678,7 @@ export default {
     /**
      * Generate an array of CRNs from this.possibilities[this.index].sections
      */
-    crns() {
+    getCrns() {
       return this.possibilities[this.index].sections.map((s) => s.crn);
     },
 

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -158,9 +158,11 @@
                     </h5>
                     <span v-if="index !== getCrns.length - 1">, </span>
                   </span>
+                  <span v-if="crnCopied" style="color: green; margin-left: 10px;">Copied!</span>
                 </div>
                 <h5>Credits: {{ totalCredits }}</h5>
               </b-col>
+
 
 
               <b-col md="3" justify="end">
@@ -335,6 +337,7 @@ export default {
       ],
       index: 0,
       loadedIndexCookie: 0,
+      crnCopied: false,
     };
   },
   methods: {
@@ -645,16 +648,17 @@ export default {
     copyToClipboard(crn) {
       navigator.clipboard.writeText(crn)
         .then(() => {
-          this.showCopyConfirmation();
+          this.crnCopied = true;
+          setTimeout(() => {
+            this.crnCopied = false;
+          }, 2000); // Hide the message after 2 seconds (adjust the delay as needed)
         })
         .catch((err) => {
           console.error('Unable to copy to clipboard: ', err);
         });
     },
-    showCopyConfirmation() {
-      alert("CRN copied to clipboard!");
-    },
   },
+  
   computed: {
     ...mapState(["subsemesters", "selectedSemester"]),
     ...mapGetters([COURSES]),

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -145,23 +145,23 @@
             <Schedule v-else :possibility="possibilities[index]"></Schedule>
 
             <b-row>
-              <!-- <b-col class="m-2">
-                <h5>CRNs:</h5>
-                <div v-for="crn in getCrns" :key="crn">
-                  <span @click="copyToClipboard(crn)" style="cursor: pointer;">{{ crn }}</span>
-                </div>
-                <h5>Credits: {{ totalCredits }}</h5>
-              </b-col> -->
               <b-col class="m-2">
                 <div style="display: inline-block;">
-                  <h5 style="display: inline; margin: 0;">CRNs: </h5>
+                  <h5 style="display: inline; margin: 0;">CRNs:</h5>
                   <span v-for="(crn, index) in getCrns" :key="index">
-                    <h5 @click="copyToClipboard(crn)" style="cursor: pointer; display: inline; margin: 0; padding: 0;">{{ crn }}</h5>
+                    <h5
+                      @click="copyToClipboard(crn)"
+                      style="cursor: pointer; display: inline; margin: 0; padding: 0;"
+                      :title="'Click to Copy ' + crn"
+                    >
+                      {{ crn }}
+                    </h5>
                     <span v-if="index !== getCrns.length - 1">, </span>
                   </span>
                 </div>
                 <h5>Credits: {{ totalCredits }}</h5>
               </b-col>
+
 
               <b-col md="3" justify="end">
                 <b-row>
@@ -669,6 +669,7 @@ export default {
         (s) => s.display_string === this.selectedScheduleSubsemester
       );
     },
+
     selectedSections() {
       return Object.values(this.selectedCourses)
         .map((c) => c.sections.filter((s) => s.selected))


### PR DESCRIPTION
**Issue**
> closes #785 

> Added copy to clipboard feature by clicking on the CRN itself. Displays "click to copy" on hover, and displays green "Copied!" message upon click.

**Photos**
After Copying:
<img width="680" alt="image" src="https://github.com/YACS-RCOS/yacs.n/assets/74884278/3a650dbf-3fdc-45a9-af13-ab4f1b07096e">
Hovering over CRN:
<img width="654" alt="image" src="https://github.com/YACS-RCOS/yacs.n/assets/74884278/6c40717a-f04c-4e20-9a79-e587648c9f48">



**Additional Info**
* Before it was just outputting an array.
* Each CRN is clickable and can be copied one at a time.
* When screenshotting, I can't show the cursor for the hover text.