### PR TITLE
817 export data finals page

### DIFF
--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -53,10 +53,10 @@
       <b-col md="7">
           <calendar :exam-details="examDetails"></calendar>
           <b-row class="justify-content-end">
-            <b-dropdown text="Export Data" class="mt-2">
+            <b-dropdown text="Export Data" class="mt-2" right="false" left="true">
               <b-dropdown-item @click="exportFinalToIcs">
                 <font-awesome-icon :icon="exportIcon" />
-                  Export To ICS
+                Export To ICS
               </b-dropdown-item>
             </b-dropdown>
           </b-row>

--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -54,13 +54,12 @@
           <calendar :exam-details="examDetails"></calendar>
           <b-row class="justify-content-end">
             <b-dropdown text="Export Data" class="mt-2">
-              <b-dropdown-item @click="exportScheduleToIcs">
+              <b-dropdown-item @click="exportFinalToIcs">
                 <font-awesome-icon :icon="exportIcon" />
-                Export To ICS
+                  Export To ICS
               </b-dropdown-item>
             </b-dropdown>
           </b-row>
-
       </b-col>
     </b-row>
   </b-container>
@@ -70,8 +69,9 @@
 import Finals from "./Finals.json";
 import Calendar from "./Calendar.vue";
 import {
-  exportScheduleToIcs,
+  exportFinalToIcs,
 } from "@/utils";
+import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
 
 
 export default {
@@ -95,6 +95,7 @@ export default {
       courseOptions: [],
       examDetails: [],
       calendarWeeks: [],
+      exportIcon: faPaperPlane,
     };
   },
   mounted() {
@@ -206,8 +207,9 @@ export default {
 
       console.log(this.examDetails);
     },
-    exportScheduleToIcs() {
-      exportScheduleToIcs(Object.values(this.possibilities[this.index]));
+    
+    exportFinalToIcs() {
+      exportFinalToIcs(this.selectedCourses);
     },
   },
 };

--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -53,12 +53,15 @@
       <b-col md="7">
           <calendar :exam-details="examDetails"></calendar>
           <b-row class="justify-content-end">
-            <b-dropdown text="Export Data" class="mt-2">
-              <b-dropdown-item @click="exportFinalToIcs">
-                <font-awesome-icon :icon="exportIcon" />
-                  Export To ICS
-              </b-dropdown-item>
-            </b-dropdown>
+            <b-col md="10"></b-col>
+            <b-col md="2">
+              <b-dropdown text="Export Data" class="mt-2">
+                <b-dropdown-item @click="exportFinalToIcs">
+                  <font-awesome-icon :icon="exportIcon" />
+                    Export To ICS
+                </b-dropdown-item>
+              </b-dropdown>
+            </b-col>
           </b-row>
       </b-col>
     </b-row>

--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -53,10 +53,10 @@
       <b-col md="7">
           <calendar :exam-details="examDetails"></calendar>
           <b-row class="justify-content-end">
-            <b-dropdown text="Export Data" class="mt-2" right="false" left="true">
+            <b-dropdown text="Export Data" class="mt-2">
               <b-dropdown-item @click="exportFinalToIcs">
                 <font-awesome-icon :icon="exportIcon" />
-                Export To ICS
+                  Export To ICS
               </b-dropdown-item>
             </b-dropdown>
           </b-row>

--- a/src/web/src/pages/FinalExamScheduler.vue
+++ b/src/web/src/pages/FinalExamScheduler.vue
@@ -51,7 +51,16 @@
         </b-card>
       </b-col>
       <b-col md="7">
-        <calendar :exam-details="examDetails"></calendar>
+          <calendar :exam-details="examDetails"></calendar>
+          <b-row class="justify-content-end">
+            <b-dropdown text="Export Data" class="mt-2">
+              <b-dropdown-item @click="exportScheduleToIcs">
+                <font-awesome-icon :icon="exportIcon" />
+                Export To ICS
+              </b-dropdown-item>
+            </b-dropdown>
+          </b-row>
+
       </b-col>
     </b-row>
   </b-container>
@@ -60,6 +69,10 @@
 <script>
 import Finals from "./Finals.json";
 import Calendar from "./Calendar.vue";
+import {
+  exportScheduleToIcs,
+} from "@/utils";
+
 
 export default {
   components: {
@@ -192,6 +205,9 @@ export default {
       this.examDetails = Object.values(examDetailsGrouped);
 
       console.log(this.examDetails);
+    },
+    exportScheduleToIcs() {
+      exportScheduleToIcs(Object.values(this.possibilities[this.index]));
     },
   },
 };

--- a/src/web/src/utils.js
+++ b/src/web/src/utils.js
@@ -346,12 +346,13 @@ export const exportFinalToIcs = (selectedSections) => {
       calendarFinals.addEvent(
         `${course.Department} ${course.CourseCode}-${course.Section}`,
         `${course.Department} Final Exam`,
-        // course.Room,
+        course.Room,
         startDate,
         endDate,
         {
-          freq: "ONCE",
+          freq: "DAILY",
           interval: 1,
+          until: endDate,
         }
       );
     });

--- a/src/web/src/utils.js
+++ b/src/web/src/utils.js
@@ -305,7 +305,7 @@ export const exportScheduleToIcs = (selectedSections) => {
  * Export all selected final exam sections to ICS
  */
 export const exportFinalToIcs = (selectedSections) => {
-  if (!Array.isArray(selectedSections) || selectedSections.length == 0) {
+  if (!Array.isArray(selectedSections) || selectedSections[0] == null) {
     alert("No final exam sections found for export to ICS.");
     return;
   }
@@ -313,53 +313,49 @@ export const exportFinalToIcs = (selectedSections) => {
   let calendarFinals = window.ics();
   let semester = "current";
 
-  try {
-    selectedSections.forEach((course) => {
-      const startTime = course.Hour.split("-")[0].trim();
-      const endTime = course.Hour.split("-")[1].trim();
+  selectedSections.forEach((course) => {
+    const startTime = course.Hour.split("-")[0].trim();
+    const endTime = course.Hour.split("-")[1].trim();
 
-      const examDate = new Date(course.Day);
-      const startDate = new Date(examDate);
+    const examDate = new Date(course.Day);
+    const startDate = new Date(examDate);
 
-      let startHour = parseInt(startTime.split(":")[0]);
-      let startMinute = parseInt(startTime.split(":")[1].substring(0, 2));
+    let startHour = parseInt(startTime.split(":")[0]);
+    let startMinute = parseInt(startTime.split(":")[1].substring(0, 2));
 
-      startDate.setHours(startHour);
-      startDate.setMinutes(startMinute);
-      startDate.setFullYear(new Date().getFullYear());
-      if (startTime.split(":")[1].substring(2) === "PM") {
-        startDate.setHours(startDate.getHours() + 12);
+    startDate.setHours(startHour);
+    startDate.setMinutes(startMinute);
+    startDate.setFullYear(new Date().getFullYear());
+    if (startTime.split(":")[1].substring(2) === "PM") {
+      startDate.setHours(startDate.getHours() + 12);
+    }
+
+    const endDate = new Date(examDate);
+
+    let endHour = parseInt(endTime.split(":")[0]);
+    let endMinute = parseInt(endTime.split(":")[1].substring(0, 2));
+    
+    endDate.setHours(endHour);
+    endDate.setMinutes(endMinute);
+    endDate.setFullYear(new Date().getFullYear());
+    if (endTime.split(":")[1].substring(2) === "PM") {
+      endDate.setHours(endDate.getHours() + 12);
+    }
+
+    calendarFinals.addEvent(
+      `${course.Department} ${course.CourseCode}-${course.Section}`,
+      `${course.Department} Final Exam`,
+      course.Room,
+      startDate,
+      endDate,
+      {
+        freq: "DAILY",
+        interval: 1,
+        until: endDate,
       }
-
-      const endDate = new Date(examDate);
-
-      let endHour = parseInt(endTime.split(":")[0]);
-      let endMinute = parseInt(endTime.split(":")[1].substring(0, 2));
-      
-      endDate.setHours(endHour);
-      endDate.setMinutes(endMinute);
-      endDate.setFullYear(new Date().getFullYear());
-      if (endTime.split(":")[1].substring(2) === "PM") {
-        endDate.setHours(endDate.getHours() + 12);
-      }
-
-      calendarFinals.addEvent(
-        `${course.Department} ${course.CourseCode}-${course.Section}`,
-        `${course.Department} Final Exam`,
-        course.Room,
-        startDate,
-        endDate,
-        {
-          freq: "DAILY",
-          interval: 1,
-          until: endDate,
-        }
-      );
-    });
-    calendarFinals.download(`${semester.replace(/\s+/g, "_")}_Final_Exams`);
-  } catch (error) {
-    alert("Error exporting final exams to ICS: " + error.message);
-  }
+    );
+  });
+  calendarFinals.download(`${semester.replace(/\s+/g, "_")}_Final_Exams`);
 };
 
 

--- a/src/web/src/utils.js
+++ b/src/web/src/utils.js
@@ -305,7 +305,7 @@ export const exportScheduleToIcs = (selectedSections) => {
  * Export all selected final exam sections to ICS
  */
 export const exportFinalToIcs = (selectedSections) => {
-  if (!Array.isArray(selectedSections) || selectedSections.length === 0) {
+  if (!Array.isArray(selectedSections) || selectedSections.length == 0) {
     alert("No final exam sections found for export to ICS.");
     return;
   }

--- a/src/web/src/utils.js
+++ b/src/web/src/utils.js
@@ -344,19 +344,17 @@ export const exportFinalToIcs = (selectedSections) => {
       }
 
       calendarFinals.addEvent(
-        `${course.CourseCode}-${course.Section}`,
-        `${course.CourseCode} Final Exam`,
-        course.Room,
+        `${course.Department} ${course.CourseCode}-${course.Section}`,
+        `${course.Department} Final Exam`,
+        // course.Room,
         startDate,
         endDate,
         {
           freq: "ONCE",
           interval: 1,
-          until: endDate,
         }
       );
     });
-    console.log(calendarFinals);
     calendarFinals.download(`${semester.replace(/\s+/g, "_")}_Final_Exams`);
   } catch (error) {
     alert("Error exporting final exams to ICS: " + error.message);

--- a/src/web/src/utils.js
+++ b/src/web/src/utils.js
@@ -302,6 +302,70 @@ export const exportScheduleToIcs = (selectedSections) => {
 };
 
 /**
+ * Export all selected final exam sections to ICS
+ */
+export const exportFinalToIcs = (selectedSections) => {
+  if (!Array.isArray(selectedSections) || selectedSections.length === 0) {
+    alert("No final exam sections found for export to ICS.");
+    return;
+  }
+
+  let calendarFinals = window.ics();
+  let semester = "current";
+
+  try {
+    selectedSections.forEach((course) => {
+      const startTime = course.Hour.split("-")[0].trim();
+      const endTime = course.Hour.split("-")[1].trim();
+
+      const examDate = new Date(course.Day);
+      const startDate = new Date(examDate);
+
+      let startHour = parseInt(startTime.split(":")[0]);
+      let startMinute = parseInt(startTime.split(":")[1].substring(0, 2));
+
+      startDate.setHours(startHour);
+      startDate.setMinutes(startMinute);
+      startDate.setFullYear(new Date().getFullYear());
+      if (startTime.split(":")[1].substring(2) === "PM") {
+        startDate.setHours(startDate.getHours() + 12);
+      }
+
+      const endDate = new Date(examDate);
+
+      let endHour = parseInt(endTime.split(":")[0]);
+      let endMinute = parseInt(endTime.split(":")[1].substring(0, 2));
+      
+      endDate.setHours(endHour);
+      endDate.setMinutes(endMinute);
+      endDate.setFullYear(new Date().getFullYear());
+      if (endTime.split(":")[1].substring(2) === "PM") {
+        endDate.setHours(endDate.getHours() + 12);
+      }
+
+      calendarFinals.addEvent(
+        `${course.CourseCode}-${course.Section}`,
+        `${course.CourseCode} Final Exam`,
+        course.Room,
+        startDate,
+        endDate,
+        {
+          freq: "ONCE",
+          interval: 1,
+          until: endDate,
+        }
+      );
+    });
+    console.log(calendarFinals);
+    calendarFinals.download(`${semester.replace(/\s+/g, "_")}_Final_Exams`);
+  } catch (error) {
+    alert("Error exporting final exams to ICS: " + error.message);
+  }
+};
+
+
+
+/**
  * Takes an object with the constant types for a vuex module and
  * the associated namespace, then adds the namespace prefix
  * to all definitions while adding a `local` property with the


### PR DESCRIPTION
**Issue**
> closes #817 

**Test Procedure**
*Example:*
> 1. Open the final exams page and add some courses
> 2. Click search, and then on the bottom click export, and then click 
> 3. Click Export Data, then export to ICS
> 4. Open Google Calendar, under other calendars, click the plus sign and click import

**Photos**

Before:
![image](https://github.com/YACS-RCOS/yacs.n/assets/74884278/fd54d3a6-7bb3-4e4c-a699-8c17c8725fb3)

After:
![image](https://github.com/YACS-RCOS/yacs.n/assets/74884278/296513ca-5a42-4a88-b179-03da0385d7de)

Google Calendar:
![image](https://github.com/YACS-RCOS/yacs.n/assets/74884278/be48db7d-4b72-4232-8b80-41a2d26b27c5)

**Additional Info**

The final exam year will default to the current year, as we only have one dataset for Finals. 