### PR TITLE
Fixed the cursor bug on Course Search and Selected Courses

### DIFF
--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -808,6 +808,10 @@ sidebar-panel-nav {
   width: 25%;
 }
 
+.nav-link.active {
+  cursor: default !important;
+}
+
 .hidden {
   visibility: hidden;
 }


### PR DESCRIPTION
**Issue**

On the schedules page, the pointer appears over the Course Search tab even though the user is on that tab. The same thing happens when the user is on the Selected Courses tab. The pointer makes it appear as if it will redirect the user somewhere else but nothing happens when clicking on it because they're already at that tab.

To Reproduce
Steps to reproduce the behavior:

Go to the Schedules page
Make sure the Course Search tab is selected
Hover over the Course Search tab

Fixed:

Fixed by adding css for boostrap in NewCourseScheduler.vue. Now if you hover over it the cursor is not a pointer but a defualt cursor
