### PR TITLE
Implemented simple dropdown feature to title to clean up explore page

### DIFF
--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -14,12 +14,17 @@
             class="departmentBox m-2 mb-4"
           >
             <b-col cols="12">
-              <!-- Department Title as a button that controls the collapse -->
-              <b-button v-b-toggle="'collapse-' + deptObj.school" class="m-1 ml-2 w-100">
+            <!-- Department Title as a ~button that controls the collapse -->
+              <b-button
+                v-b-toggle="'collapse-' + deptObj.school"
+                class="button"
+                variant="outline-secondary"
+              >
                 <h3>
                   {{ deptObj.school }}
                 </h3>
-              </b-button>
+              </b-button>          
+              <hr />
               <!-- Subject Title inside a b-collapse -->
               <b-collapse :id="'collapse-' + deptObj.school">
                 <b-row>
@@ -158,4 +163,39 @@ export default {
   background: rgba(108, 90, 90, 0.15);
   border-bottom: rgba(108, 90, 90, 0.1), solid, 1px;
 }
+
+.button {
+  width: 100%;
+  text-align: left;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 500;
+  color: #3395ff !important;
+  text-decoration: none;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.button:hover {
+  background-color: rgba(108, 90, 90, 0.15);
+}
+
+.button:focus {
+  background-color: transparent;
+  box-shadow: none !important;
+  outline: none !important;
+
+}
+
+.button:active {
+  background-color: transparent !important;
+  color: #3395ff;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
 </style>

--- a/src/web/src/pages/CourseExplorer.vue
+++ b/src/web/src/pages/CourseExplorer.vue
@@ -3,32 +3,33 @@
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
     <div v-if="!isLoadingCourses && courses.length > 0" class="mx-auto w-75">
       <b-row>
-        <!-- 2 arrays in schoolDepartmentObjects, so 2 columns -->
         <b-col
           v-for="(deptCol, index) in schoolDepartmentObjects"
           :key="`deptCol-${index}`"
-          md="6"
+          cols="12"
         >
           <b-row
             v-for="deptObj in deptCol"
             :key="deptObj.school"
-            class="departmentBox border m-2 mb-4"
+            class="departmentBox m-2 mb-4"
           >
-            <b-col>
-              <!-- Department Title  -->
-              <b-row class="school-name">
-                <h3 class="m-1 ml-2">
+            <b-col cols="12">
+              <!-- Department Title as a button that controls the collapse -->
+              <b-button v-b-toggle="'collapse-' + deptObj.school" class="m-1 ml-2 w-100">
+                <h3>
                   {{ deptObj.school }}
                 </h3>
-              </b-row>
-              <!-- Subject Title  -->
-              <b-row>
-                <DepartmentList
-                  :majors="deptObj.departments"
-                  :deptClassDict="deptClassDict"
-                  v-on:showCourseInfo="showCourseInfo($event)"
-                ></DepartmentList>
-              </b-row>
+              </b-button>
+              <!-- Subject Title inside a b-collapse -->
+              <b-collapse :id="'collapse-' + deptObj.school">
+                <b-row>
+                  <DepartmentList
+                    :majors="deptObj.departments"
+                    :deptClassDict="deptClassDict"
+                    v-on:showCourseInfo="showCourseInfo($event)"
+                  ></DepartmentList>
+                </b-row>
+              </b-collapse>
             </b-col>
           </b-row>
         </b-col>


### PR DESCRIPTION
**Issue**

> closes #851 

**Changes Made**

> Changed the explore page from a grid to a series of dropdowns. 

**Photos**

**Before:**
![image](https://github.com/YACS-RCOS/yacs.n/assets/59715002/759a9ff7-0364-419e-a813-25714863fe6c)

**After:**
![image](https://github.com/YACS-RCOS/yacs.n/assets/59715002/e6386599-3778-466a-8ce0-676124f38503)

**Functionality:**
![yacs explore page new](https://github.com/YACS-RCOS/yacs.n/assets/59715002/3de34eee-2352-4319-aca4-ef9f58d9ac2a)

**Additional Info**

Working on adding animated chevron to help indicate the button is a dropdown.