### PR TITLE
Fixed bug with footer text not changing

### DIFF
--- a/src/web/src/assets/dark.scss
+++ b/src/web/src/assets/dark.scss
@@ -38,7 +38,7 @@
   }
 
   #credits {
-    background: var(--dark-primary) !important;
+    color: var(--dark-text-primary) !important;
   }
 
   #footer {


### PR DESCRIPTION
**Issue**

Some of the text in the footer of all pages does not change when shifted between light and dark mode. As such, one can barely see it. All the text now changes though with this fix.

*Example:*
> closes #879  