### PR TITLE
Mobile View rework

### DIFF
--- a/src/web/src/components/Header.vue
+++ b/src/web/src/components/Header.vue
@@ -33,6 +33,7 @@
     <b-navbar-toggle
       id="header-navbar-collapse-toggle"
       target="header-navbar-collapse"
+      :class="darkMode === true ? 'dark-mode-toggle' : darkMode === false ? 'light-mode-toggle' : ''"
     >
       <font-awesome-icon icon="bars" />
     </b-navbar-toggle>
@@ -270,9 +271,11 @@ export default {
   padding: calc(8px - 0.2em);
   border: 0.2em solid var(--dark-blue-secondary);
 }
-// no idea why but need to manually set this for it to show up
-.dark #header-navbar-collapse-toggle {
+.dark-mode-toggle {
   color: var(--dark-text-primary) !important;
+}
+.light-mode-toggle {
+  color: var(--light-text-primary) !important;
 }
 .drop-down-item {
   background: hsl(211, 100%, 60%) !important;

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -21,77 +21,6 @@
             </button>
           </slot>
         </div>
-        <div class="sidebar">
-          <!--<div class="sidebar-backdrop" v-if="isNavOpen"></div>-->
-          <transition name="slide">
-            <div v-if="isNavOpen" class="sidebar-panel">
-              <div class="sidebar-panal-nav" style="height: 100%;">
-                <b-col
-                  class="d-flex flex-column"
-                  ref="sidebar"
-                  style="height: 100%; padding: 1px;"
-                >
-                  <b-card no-body class="h-100">
-                    <b-tabs card class="h-100 d-flex flex-column flex-grow-1">
-                      <b-tab
-                        title="Course Search"
-                        active
-                        class="flex-grow-1 w-100"
-                        data-cy="course-search-tab"
-                      >
-                        <b-card-text class="d-flex flex-grow-1 w-100">
-                          <CenterSpinner
-                            v-if="loading"
-                            class="d-flex flex-grow-1 flex-column w-100 justify-content-center align-items-center"
-                            :height="60"
-                            :fontSize="1"
-                            loadingMessage="Courses"
-                            :topSpacing="0"
-                          />
-
-                          <CourseList
-                            v-if="!loading"
-                            @addCourse="addCourse"
-                            @removeCourse="removeCourse"
-                            @showCourseInfo="showCourseInfo"
-                            class="w-100"
-                          />
-                        </b-card-text>
-                      </b-tab>
-                      <b-tab class="flex-grow-1" data-cy="selected-courses-tab">
-                        <template v-slot:title>
-                          <div
-                            class="text-center"
-                            data-cy="selected-courses-tab-header"
-                          >
-                            Selected Courses
-                            <b-badge
-                              variant="light"
-                              data-cy="num-selected-courses"
-                            >
-                              {{ numSelectedCourses }}
-                            </b-badge>
-                          </div>
-                        </template>
-                        <b-card-text
-                          class="w-100 d-flex flex-grow-1 flex-column"
-                        >
-                          <SelectedCourses
-                            :courses="selectedCourses"
-                            @removeCourse="removeCourse"
-                            @removeCourseSection="removeCourseSection"
-                            @addCourseSection="addCourseSection"
-                          />
-                        </b-card-text>
-                      </b-tab>
-                    </b-tabs>
-                  </b-card>
-                </b-col>
-              </div>
-              <slot></slot>
-            </div>
-          </transition>
-        </div>
         <b-form-select
           v-if="
             !loading &&
@@ -177,6 +106,77 @@
               </b-col>
             </b-row>
           </div>
+        </div>
+        <div class="sidebar">
+          <!--<div class="sidebar-backdrop" v-if="isNavOpen"></div>-->
+          <transition name="slide">
+            <div v-if="isNavOpen" class="sidebar-panel">
+              <div class="sidebar-panal-nav" style="height: 100%;">
+                <b-col
+                  class="d-flex flex-column"
+                  ref="sidebar"
+                  style="height: 100%; padding: 1px;"
+                >
+                  <b-card no-body class="h-100">
+                    <b-tabs card class="h-100 d-flex flex-column flex-grow-1">
+                      <b-tab
+                        title="Course Search"
+                        active
+                        class="flex-grow-1 w-100"
+                        data-cy="course-search-tab"
+                      >
+                        <b-card-text class="d-flex flex-grow-1 w-100">
+                          <CenterSpinner
+                            v-if="loading"
+                            class="d-flex flex-grow-1 flex-column w-100 justify-content-center align-items-center"
+                            :height="60"
+                            :fontSize="1"
+                            loadingMessage="Courses"
+                            :topSpacing="0"
+                          />
+
+                          <CourseList
+                            v-if="!loading"
+                            @addCourse="addCourse"
+                            @removeCourse="removeCourse"
+                            @showCourseInfo="showCourseInfo"
+                            class="w-100"
+                          />
+                        </b-card-text>
+                      </b-tab>
+                      <b-tab class="flex-grow-1" data-cy="selected-courses-tab">
+                        <template v-slot:title>
+                          <div
+                            class="text-center"
+                            data-cy="selected-courses-tab-header"
+                          >
+                            Selected Courses
+                            <b-badge
+                              variant="light"
+                              data-cy="num-selected-courses"
+                            >
+                              {{ numSelectedCourses }}
+                            </b-badge>
+                          </div>
+                        </template>
+                        <b-card-text
+                          class="w-100 d-flex flex-grow-1 flex-column"
+                        >
+                          <SelectedCourses
+                            :courses="selectedCourses"
+                            @removeCourse="removeCourse"
+                            @removeCourseSection="removeCourseSection"
+                            @addCourseSection="addCourseSection"
+                          />
+                        </b-card-text>
+                      </b-tab>
+                    </b-tabs>
+                  </b-card>
+                </b-col>
+              </div>
+              <slot></slot>
+            </div>
+          </transition>
         </div>
       </div>
     </b-row>

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -712,12 +712,6 @@ export default {
 // This means that all v-tabs in this app will have flexbox content
 // Hopefully this doesn't screw up someone's debugging later lol
 
-@media (min-width: 1025px) {
-  .main-body {
-    min-height: 100vh;
-  }
-}
-
 .d-flex flex-column {
   transition: 0.5s;
   background-color: #111;
@@ -813,29 +807,6 @@ sidebar-panel-nav {
   z-index: 999;
   margin: 60px 0px 0px;
   width: 25%;
-}
-
-@media (max-width: 768px) {
-  // basically mobile view showing sidebar at bottom instead
-  .main-body {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .sidebar-panel {
-    position: static;
-    width: 100%;
-    height: auto;
-    margin: 0;
-  }
-
-  .sidebar {
-    padding: 0;
-  }
-
-  .schedule-navigation {
-    padding: 0;
-  }
 }
 
 .hidden {
@@ -941,4 +912,43 @@ button:focus {
 #burger.active .burger-bar {
   background-color: #32aad8;
 }
+
+@media (min-width: 1025px) {
+  .main-body {
+    min-height: 100vh;
+  }
+}
+
+@media (max-width: 768px) {
+  // basically mobile view showing sidebar at bottom instead
+  .main-body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  h5 {
+    font-size: .9em;
+  }
+
+  // the arrow that makes the sidebar appear or not
+  #burger {
+    display: none;
+  }
+
+  .sidebar-panel {
+    position: static;
+    width: 100%;
+    height: auto;
+    margin: 0;
+  }
+
+  .sidebar {
+    padding: 0;
+  }
+
+  .schedule-navigation {
+    padding: 0;
+  }
+}
+
 </style>

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -808,6 +808,25 @@ sidebar-panel-nav {
   width: 25%;
 }
 
+@media (max-width: 768px) {
+  .sidebar-panel {
+    position: static;
+    width: 100%;
+    height: auto;
+    margin: 0;
+    z-index: 1;
+  }
+
+  .sidebar {
+    padding: 0;
+  }
+
+  .main-body {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
 .hidden {
   visibility: hidden;
 }

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -36,7 +36,7 @@
           <div>
             <!-- Desktop view -->
             <b-row class="justify-content-between align-items-center desktop-schedule-navigation">
-              <b-col cols="auto">
+              <b-col cols="auto" class="schedule-navigation">
                 <b-button
                   @click="
                     changeSchedule(-1);
@@ -59,7 +59,7 @@
                   {{ this.possibilities.length }}
                 </span>
               </b-col>
-              <b-col cols="auto">
+              <b-col cols="auto" class="schedule-navigation">
                 <b-button
                   @click="
                     changeSchedule(1);
@@ -76,7 +76,7 @@
             <b-row
               class="d-flex flex-column align-items-center text-center mobile-schedule-navigation"
             >
-              <b-col cols="12">
+              <b-col cols="12" class="pt-2">
                 <span v-if="scheduleDisplayMessage === 2">
                   Add some sections to generate schedules!
                 </span>
@@ -89,7 +89,7 @@
                 </span>
               </b-col>
               <b-row class="w-100 justify-content-between">
-                <b-col cols="auto">
+                <b-col cols="auto" class="schedule-navigation">
                   <b-button
                     @click="
                       changeSchedule(-1);
@@ -100,7 +100,7 @@
                     Prev
                   </b-button>
                 </b-col>
-                <b-col cols="auto">
+                <b-col cols="auto" class="schedule-navigation">
                   <b-button
                     @click="
                       changeSchedule(1);
@@ -780,7 +780,7 @@ export default {
 }
 
 // This is for the button for navigating each schedule option
-#allScheduleData {
+.schedule-navigation {
   margin: 8px;
 }
 
@@ -964,18 +964,19 @@ button:focus {
 }
 
 .desktop-schedule-navigation {
-  visibility: visible;
+  display: flex;
 }
 
 .mobile-schedule-navigation {
-  visibility: hidden;
+  display: none;
   height: 0;
+  overflow: hidden;
 }
 
 @media (max-width: 768px) {
   // basically mobile view showing sidebar at bottom instead
   .main-body {
-    display: flex;
+    display: block;
     flex-direction: column;
   }
 
@@ -998,19 +999,17 @@ button:focus {
     padding: 0;
   }
 
-  #allScheduleData {
-    margin: 4px;
+  .schedule-navigation {
+    margin: 0px;
   }
 
   .desktop-schedule-navigation {
-    visibility: hidden;
-    height: 0;
+    display: none;
   }
 
   .mobile-schedule-navigation {
-    visibility: visible;
+    display: flex;
     height: auto;
-    padding: 10px;
   }
 }
 

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -33,8 +33,9 @@
           value-field="display_string"
         ></b-form-select>
         <div id="allScheduleData" class="justify-content-right">
+          <!-- Made two seperate schedule navigators which turn on and off depending on mobile view -->
           <div>
-            <!-- Desktop view -->
+            <!-- Desktop view - Display Message between the two change schedule buttons -->
             <b-row class="justify-content-between align-items-center desktop-schedule-navigation">
               <b-col cols="auto" class="schedule-navigation">
                 <b-button
@@ -72,7 +73,7 @@
               </b-col>
             </b-row>
 
-            <!-- Mobile view -->
+            <!-- Mobile view  - Display Message First then change schedule buttons -->
             <b-row
               class="d-flex flex-column align-items-center text-center mobile-schedule-navigation"
             >
@@ -149,6 +150,7 @@
           </div>
         </div>
         <div class="sidebar">
+          <!-- Side bar or course selector and code below is for future changes in case-->
           <!--<div class="sidebar-backdrop" v-if="isNavOpen"></div>-->
           <transition name="slide">
             <div v-if="isNavOpen" class="sidebar-panel">
@@ -175,7 +177,6 @@
                             loadingMessage="Courses"
                             :topSpacing="0"
                           />
-
                           <CourseList
                             v-if="!loading"
                             @addCourse="addCourse"
@@ -957,12 +958,6 @@ button:focus {
   background-color: #32aad8;
 }
 
-@media (min-width: 1025px) {
-  .main-body {
-    min-height: 100vh;
-  }
-}
-
 .desktop-schedule-navigation {
   display: flex;
 }
@@ -973,8 +968,14 @@ button:focus {
   overflow: hidden;
 }
 
+@media (min-width: 1025px) {
+  .main-body {
+    min-height: 100vh;
+  }
+}
+
 @media (max-width: 768px) {
-  // basically mobile view showing sidebar at bottom instead
+  // basically mobile view showing sidebar at bottom instead so its no longer a sidebar
   .main-body {
     display: block;
     flex-direction: column;
@@ -1002,7 +1003,7 @@ button:focus {
   .schedule-navigation {
     margin: 0px;
   }
-
+  
   .desktop-schedule-navigation {
     display: none;
   }

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -34,8 +34,8 @@
         ></b-form-select>
         <div id="allScheduleData" class="justify-content-right">
           <div>
-            <b-row>
-              <b-col class="m-2">
+            <b-row class="justify-content-between align-items-center">
+              <b-col cols="auto" class="m-2">
                 <b-button
                   @click="
                     changeSchedule(-1);
@@ -46,7 +46,7 @@
                   Prev
                 </b-button>
               </b-col>
-              <b-col cols="8" class="m-2 text-center">
+              <b-col cols="auto">
                 <span v-if="scheduleDisplayMessage === 2">
                   Add some sections to generate schedules!
                 </span>
@@ -58,7 +58,7 @@
                   {{ this.possibilities.length }}
                 </span>
               </b-col>
-              <b-col class="m-2 text-right">
+              <b-col cols="auto" class="m-2">
                 <b-button
                   @click="
                     changeSchedule(1);

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -108,7 +108,7 @@
           <!--<div class="sidebar-backdrop" v-if="isNavOpen"></div>-->
           <transition name="slide">
             <div v-if="isNavOpen" class="sidebar-panel">
-              <div class="sidebar-panal-nav" style="height: 100%;">
+              <div class="sidebar-panel-nav" style="height: 100%;">
                 <b-col
                   class="d-flex flex-column"
                   ref="sidebar"
@@ -938,7 +938,6 @@ button:focus {
   .sidebar-panel {
     position: static;
     width: 100%;
-    height: auto;
     margin: 0;
   }
 

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -35,7 +35,7 @@
         <div id="allScheduleData" class="justify-content-right">
           <div>
             <b-row class="justify-content-between align-items-center">
-              <b-col cols="auto" class="m-2">
+              <b-col cols="auto" class="schedule-navigation">
                 <b-button
                   @click="
                     changeSchedule(-1);
@@ -58,7 +58,7 @@
                   {{ this.possibilities.length }}
                 </span>
               </b-col>
-              <b-col cols="auto" class="m-2">
+              <b-col cols="auto" class="schedule-navigation">
                 <b-button
                   @click="
                     changeSchedule(1);
@@ -741,6 +741,11 @@ export default {
   display: flex;
 }
 
+// This is for the button for navigating each schedule option
+.schedule-navigation {
+  margin: 8px;
+}
+
 .card {
   border: none !important;
   font-size: 17px;
@@ -825,6 +830,10 @@ sidebar-panel-nav {
   }
 
   .sidebar {
+    padding: 0;
+  }
+
+  .schedule-navigation {
     padding: 0;
   }
 }

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -34,8 +34,9 @@
         ></b-form-select>
         <div id="allScheduleData" class="justify-content-right">
           <div>
-            <b-row class="justify-content-between align-items-center">
-              <b-col cols="auto" class="schedule-navigation">
+            <!-- Desktop view -->
+            <b-row class="justify-content-between align-items-center desktop-schedule-navigation">
+              <b-col cols="auto">
                 <b-button
                   @click="
                     changeSchedule(-1);
@@ -58,7 +59,7 @@
                   {{ this.possibilities.length }}
                 </span>
               </b-col>
-              <b-col cols="auto" class="schedule-navigation">
+              <b-col cols="auto">
                 <b-button
                   @click="
                     changeSchedule(1);
@@ -70,6 +71,49 @@
                 </b-button>
               </b-col>
             </b-row>
+
+            <!-- Mobile view -->
+            <b-row
+              class="d-flex flex-column align-items-center text-center mobile-schedule-navigation"
+            >
+              <b-col cols="12">
+                <span v-if="scheduleDisplayMessage === 2">
+                  Add some sections to generate schedules!
+                </span>
+                <span v-else-if="scheduleDisplayMessage === 3">
+                  Can't display because of course conflict!
+                </span>
+                <span v-else>
+                  Displaying schedule {{ this.index + 1 }} out of
+                  {{ this.possibilities.length }}
+                </span>
+              </b-col>
+              <b-row class="w-100 justify-content-between">
+                <b-col cols="auto">
+                  <b-button
+                    @click="
+                      changeSchedule(-1);
+                      updateIndexCookie();
+                    "
+                    size="sm"
+                  >
+                    Prev
+                  </b-button>
+                </b-col>
+                <b-col cols="auto">
+                  <b-button
+                    @click="
+                      changeSchedule(1);
+                      updateIndexCookie();
+                    "
+                    size="sm"
+                  >
+                    Next
+                  </b-button>
+                </b-col>
+              </b-row>
+            </b-row>
+
             <Schedule v-if="loading" />
             <Schedule v-else :possibility="possibilities[index]"></Schedule>
             <b-row class="align-items-center">
@@ -736,7 +780,7 @@ export default {
 }
 
 // This is for the button for navigating each schedule option
-.schedule-navigation {
+#allScheduleData {
   margin: 8px;
 }
 
@@ -919,6 +963,15 @@ button:focus {
   }
 }
 
+.desktop-schedule-navigation {
+  visibility: visible;
+}
+
+.mobile-schedule-navigation {
+  visibility: hidden;
+  height: 0;
+}
+
 @media (max-width: 768px) {
   // basically mobile view showing sidebar at bottom instead
   .main-body {
@@ -945,8 +998,19 @@ button:focus {
     padding: 0;
   }
 
-  .schedule-navigation {
-    padding: 0;
+  #allScheduleData {
+    margin: 4px;
+  }
+
+  .desktop-schedule-navigation {
+    visibility: hidden;
+    height: 0;
+  }
+
+  .mobile-schedule-navigation {
+    visibility: visible;
+    height: auto;
+    padding: 10px;
   }
 }
 

--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -72,37 +72,34 @@
             </b-row>
             <Schedule v-if="loading" />
             <Schedule v-else :possibility="possibilities[index]"></Schedule>
-
-            <b-row>
+            <b-row class="align-items-center">
+              <!-- CRNs and Credits -->
               <b-col class="m-2">
                 <h5>CRNs: {{ selectedCrns }}</h5>
                 <h5>Credits: {{ totalCredits }}</h5>
               </b-col>
-
-              <b-col md="3" justify="end">
-                <b-row>
-                  <b-form-checkbox
-                    class="mt-2"
-                    size="sm"
-                    :checked="$store.state.colorBlindAssist"
-                    @change="toggleColors()"
-                    switch
-                  >
-                    Color Blind Assistance
-                  </b-form-checkbox>
-                </b-row>
-                <b-row>
-                  <b-dropdown text="Export Data" class="mt-2">
-                    <b-dropdown-item @click="exportScheduleToIcs">
-                      <font-awesome-icon :icon="exportIcon" />
-                      Export To ICS
-                    </b-dropdown-item>
-                    <b-dropdown-item @click="exportScheduleToImage">
-                      <font-awesome-icon :icon="exportIcon" />
-                      Export To Image
-                    </b-dropdown-item>
-                  </b-dropdown>
-                </b-row>
+              <!-- Color Blind Assistance -->
+              <b-col class="m-2 d-flex flex-column align-items-end">
+                <b-form-checkbox
+                  class="mt-2"
+                  size="sm"
+                  :checked="$store.state.colorBlindAssist"
+                  @change="toggleColors()"
+                  switch
+                >
+                  Color Blind Assistance
+                </b-form-checkbox>
+                <!-- Export Data with dropdown aligned to the right -->
+                <b-dropdown text="Export Data" class="mt-2" right>
+                  <b-dropdown-item @click="exportScheduleToIcs">
+                    <font-awesome-icon :icon="exportIcon" />
+                    Export To ICS
+                  </b-dropdown-item>
+                  <b-dropdown-item @click="exportScheduleToImage">
+                    <font-awesome-icon :icon="exportIcon" />
+                    Export To Image
+                  </b-dropdown-item>
+                </b-dropdown>
               </b-col>
             </b-row>
           </div>
@@ -773,6 +770,11 @@ sidebar-panel-nav {
   background: #3d4959 !important;
 }
 
+.b-dropdown .dropdown-menu {
+  // shifts export data menu left
+  transform: translateX(-10px);
+}
+
 .slide-enter-active,
 .slide-leave-active {
   transition: transform 0.2s ease;
@@ -809,21 +811,21 @@ sidebar-panel-nav {
 }
 
 @media (max-width: 768px) {
+  // basically mobile view showing sidebar at bottom instead
+  .main-body {
+    display: flex;
+    flex-direction: column;
+  }
+
   .sidebar-panel {
     position: static;
     width: 100%;
     height: auto;
     margin: 0;
-    z-index: 1;
   }
 
   .sidebar {
     padding: 0;
-  }
-
-  .main-body {
-    display: flex;
-    flex-direction: column;
   }
 }
 

--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -4,16 +4,8 @@
 
     <!-- button to switch between alphabet order and category order -->
     <div class="filter-buttons w-10" style="float: left;">
-      <b-button
-        @click="listAlphabet()"
-      >
-        List by Alphabet
-      </b-button>
-      <b-button
-        @click="listCate()"
-      >
-        List by Category
-      </b-button>
+      <b-button @click="listAlphabet()"> List by Alphabet </b-button>
+      <b-button @click="listCate()"> List by Category </b-button>
     </div>
     <div v-if="categories.length > 0" class="mx-auto w-75">
       <!-- pop-up window -->
@@ -354,7 +346,7 @@ export default {
   display: inline-block;
   background: white;
   border-style: none;
-  text-align: justify;
+  text-align: left;
   width: 95%;
 }
 

--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -354,6 +354,7 @@ export default {
 }
 
 @media (max-width: 768px) {
+  /* in mobile mode move filters above pathways so mobile view doesn't get smushed */
   .filter-buttons {
     float: none;
     display: flex;

--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -4,8 +4,12 @@
 
     <!-- button to switch between alphabet order and category order -->
     <div class="filter-buttons w-10" style="float: left;">
-      <b-button @click="listAlphabet()"> List by Alphabet </b-button>
-      <b-button @click="listCate()"> List by Category </b-button>
+      <b-button @click="listAlphabet()"> 
+        List by Alphabet 
+      </b-button>
+      <b-button @click="listCate()"> 
+        List by Category 
+      </b-button>
     </div>
     <div v-if="categories.length > 0" class="mx-auto w-75">
       <!-- pop-up window -->
@@ -309,20 +313,7 @@ export default {
   color: #007bff;
   border: solid #007bff;
   background-color: transparent;
-  margin: 0;
-}
-
-@media (max-width: 768px) {
-  .filter-buttons {
-    float: none;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    margin-bottom: 20px;
-    gap: 5px;
-  }
+  width: 100%;
 }
 
 .gridContainer {
@@ -333,7 +324,7 @@ export default {
 }
 
 .categoryBox {
-  text-align: center;
+  text-align: left;
 }
 
 .category-title {
@@ -360,5 +351,18 @@ export default {
 
 .courseInPath:hover {
   background-color: rgba(39, 130, 230, 0.5);
+}
+
+@media (max-width: 768px) {
+  .filter-buttons {
+    float: none;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 20px;
+    gap: 5px;
+  }
 }
 </style>

--- a/src/web/src/pages/Pathway.vue
+++ b/src/web/src/pages/Pathway.vue
@@ -3,27 +3,14 @@
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
 
     <!-- button to switch between alphabet order and category order -->
-    <div style="float: left;" class="w-10">
+    <div class="filter-buttons w-10" style="float: left;">
       <b-button
         @click="listAlphabet()"
-        style="
-          margin-top: 10px;
-          color: #007bff;
-          border: solid #007bff;
-          background-color: transparent;
-        "
       >
         List by Alphabet
       </b-button>
-      <br />
       <b-button
         @click="listCate()"
-        style="
-          margin-top: 10px;
-          color: #007bff;
-          border: solid #007bff;
-          background-color: transparent;
-        "
       >
         List by Category
       </b-button>
@@ -317,6 +304,35 @@ export default {
 </script>
 
 <style>
+
+.filter-buttons {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.filter-buttons button {
+  color: #007bff;
+  border: solid #007bff;
+  background-color: transparent;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .filter-buttons {
+    float: none;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 20px;
+    gap: 5px;
+  }
+}
+
 .gridContainer {
   display: inline-grid;
   grid-template-columns: auto auto;

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -4,8 +4,12 @@
 
     <!-- button to switch between alphabet order and department order -->
     <div class="filter-buttons w-10" style="float: left;">
-      <b-button @click="listAlphabet()"> List by Alphabet </b-button>
-      <b-button @click="listDepartment()"> List by Department </b-button>
+      <b-button @click="listAlphabet()"> 
+        List by Alphabet 
+      </b-button>
+      <b-button @click="listDepartment()"> 
+        List by Department 
+      </b-button>
     </div>
 
     <div v-if="professors.length > 0" class="mx-auto w-75">
@@ -361,20 +365,7 @@ export default {
   color: #007bff;
   border: solid #007bff;
   background-color: transparent;
-  margin: 0;
-}
-
-@media (max-width: 768px) {
-  .filter-buttons {
-    float: none;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    margin-bottom: 20px;
-    gap: 5px;
-  }
+  width: 100%;
 }
 
 .gridContainer {
@@ -406,5 +397,18 @@ export default {
 
 .h3 {
   text-align: left;
+}
+
+@media (max-width: 768px) {
+  .filter-buttons {
+    float: none;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 20px;
+    gap: 5px;
+  }
 }
 </style>

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -3,32 +3,9 @@
     <b-breadcrumb :items="breadcrumbNav"></b-breadcrumb>
 
     <!-- button to switch between alphabet order and department order -->
-    <div style="float: left;" class="w-10">
-      <b-button
-        @click="listAlphabet()"
-        style="
-          margin-top: 10px;
-          color: #007bff;
-          border: solid #007bff;
-          background-color: transparent;
-          width: 100%;
-        "
-      >
-        List by Alphabet
-      </b-button>
-      <br />
-      <b-button
-        @click="listDepartment()"
-        style="
-          margin-top: 10px;
-          color: #007bff;
-          border: solid #007bff;
-          background-color: transparent;
-          width: 100%;
-        "
-      >
-        List by Department
-      </b-button>
+    <div class="filter-buttons w-10" style="float: left;">
+      <b-button @click="listAlphabet()"> List by Alphabet </b-button>
+      <b-button @click="listDepartment()"> List by Department </b-button>
     </div>
 
     <div v-if="professors.length > 0" class="mx-auto w-75">
@@ -371,6 +348,35 @@ export default {
 </script>
 
 <style>
+
+.filter-buttons {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.filter-buttons button {
+  color: #007bff;
+  border: solid #007bff;
+  background-color: transparent;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .filter-buttons {
+    float: none;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 20px;
+    gap: 5px;
+  }
+}
+
 .gridContainer {
   display: inline-grid;
   grid-template-columns: auto auto;
@@ -388,7 +394,7 @@ export default {
   display: inline-block;
   background: white;
   border-style: none;
-  text-align: justify;
+  text-align: left;
   width: 95%;
   padding-top: 0;
   padding-bottom: 0;

--- a/src/web/src/pages/ProfExplorer.vue
+++ b/src/web/src/pages/ProfExplorer.vue
@@ -401,6 +401,7 @@ export default {
 
 @media (max-width: 768px) {
   .filter-buttons {
+    /* in mobile mode move filters above professors so mobile view doesn't get smushed */
     float: none;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
**Issue**
Fix the mobile view for the YACS pages so it is usable in mobile view.
closes #896 

**Photos**

Before
The sidebar is overlapping with the schedule which makes things hard to see and pushing it to the side.
![image](https://github.com/user-attachments/assets/ea0881d7-d714-43c7-a7d1-2877cda70dd4)
The color assistance button and export data are not placed on the right and is taking too much unnecessary space.
![image](https://github.com/user-attachments/assets/00bd83a2-193c-4e44-add5-301e3e10f22e)
Filter button pushes professors too far to the right so its hard to read.
![image](https://github.com/user-attachments/assets/496b8eca-bb59-434e-a2b8-59de9d614de8)

After
Moved sidebar to the bottom and removed the open and close sidebar when in mobile view so efficiently use space.
![image](https://github.com/user-attachments/assets/cd2a6b94-5804-41ea-8fb3-78e1909ba5f3)
![image](https://github.com/user-attachments/assets/8dd97add-f5e2-40db-b941-a7a15390969f)
Fixed professor and pathways pages by moving the filter buttons to the top to avoid pushing the info and making it hard to read.
![image](https://github.com/user-attachments/assets/288f6edf-fbac-48aa-84fd-f0c015e41c52)
![image](https://github.com/user-attachments/assets/f577b56c-756f-4a26-868d-ffcb5b37c84a)

**Additional Info**

Use ctrl-shift-i and control-shift-m to see mobile view or just move the website to the side