### PR TITLE
Course elements persistence 

### DIFF
--- a/src/web/src/pages/NewCourseScheduler.vue
+++ b/src/web/src/pages/NewCourseScheduler.vue
@@ -366,6 +366,14 @@ export default {
       loadedIndexCookie: 0,
     };
   },
+  mounted() {
+    // Reload the schedule when the component is mounted
+    this.reloadSchedule();
+  },
+  // NEW: When the component is re-activated (if using keep-alive), reload the schedule
+  activated() {
+    this.reloadSchedule();
+  },
   methods: {
     toggleNav() {
       this.isNavOpen = !this.isNavOpen;
@@ -468,9 +476,8 @@ export default {
                     (section) => section.crn === selectedSectionCrn
                   );
 
-                  section.selected = true;
-                }
-              );
+                section.selected = true;
+              });
             });
         } catch (err) {
           // If there is an error here, it might mean the data was changed,
@@ -670,6 +677,12 @@ export default {
         .updateIndex(this.index)
         .save();
     },
+    // Reload the schedule when returning to this page
+    reloadSchedule() {
+      if (Object.keys(this.selectedCourses).length > 0) {
+        this.getSchedules();
+      }
+    },
   },
   computed: {
     ...mapState(["subsemesters", "selectedSemester"]),
@@ -728,6 +741,12 @@ export default {
     },
   },
   watch: {
+    // ─── Watch for route changes to trigger schedule reload ──────────────
+    $route(to) {
+      if (to.name === "SchedulePage") {
+        this.reloadSchedule();
+      }
+    },
     courses: {
       immediate: true,
       handler() {


### PR DESCRIPTION
Issue
closes #763

Database Changes/Migrations
No database schema changes were done for this fix.

Test Modifications
Added tests to verify that the schedule persists when navigating away from and back to the schedule page. 


Test Procedure

Checkout the branch containing this commit.
Start the application locally (http://localhost:8080/).
On the schedule page, verify that your selected courses and schedule details are displayed.
Navigate to another route (e.g., http://localhost:8080/explore).
Return to the schedule page (http://localhost:8080/) and confirm that the schedule still displays correctly without needing a full page refresh.
Verify that UI states (e.g., course selections and class details) persist as expected.
Photos
Before: https://gyazo.com/fef9ac4e0f0ccf5235803bb58380eac1
After:  https://gyazo.com/95b9549c07d4ac48529cebb58a432563

Additional Info
Noticed this issue occured when you weren't logged in. 
Added an activated() lifecycle hook to the scheduler component to reload the schedule when the component is re-activated (i.e., when using <keep-alive>).
This fix addresses an issue where switching routes caused the schedule’s CSS classes to disappear until a manual refresh occurred.
Commit details: [c3d8f4565885dc4d247c084ea2dd0132b7cd91af](https://github.com/TroyG-11/yacs.n/commit/c3d8f4565885dc4d247c084ea2dd0132b7cd91af)